### PR TITLE
Performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ compiler:
 
 env:
   - BUILD_TYPE=Debug
+    CXXFLAGS="${CXXFLAGS} -pthread"
   - BUILD_TYPE=Release
+    CXXFLAGS="${CXXFLAGS} -pthread"
 
 install:
   # Prerequisites

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ compiler:
 env:
   - BUILD_TYPE=Debug
   - BUILD_TYPE=Release
+  - CXXFLAGS="${CXXFLAGS} -pthread"
 
 install:
   # Prerequisites

--- a/include/plog/Appenders/RollingFileAppender.h
+++ b/include/plog/Appenders/RollingFileAppender.h
@@ -20,6 +20,7 @@ namespace plog
 
         virtual void write(const Record& record)
         {
+			const std::string line = Converter::convert(Formatter::format(record));
             util::MutexLock lock(m_mutex);
 
             if (m_firstWrite)
@@ -32,7 +33,7 @@ namespace plog
                 rollLogFiles();
             }
 
-            int bytesWritten = m_file.write(Converter::convert(Formatter::format(record)));
+            int bytesWritten = m_file.write(line);
 
             if (bytesWritten > 0)
             {

--- a/include/plog/Appenders/RollingFileAppender.h
+++ b/include/plog/Appenders/RollingFileAppender.h
@@ -20,7 +20,7 @@ namespace plog
 
         virtual void write(const Record& record)
         {
-			const std::string line = Converter::convert(Formatter::format(record));
+            const std::string line = Converter::convert(Formatter::format(record));
             util::MutexLock lock(m_mutex);
 
             if (m_firstWrite)

--- a/include/plog/Formatters/TxtFormatter.h
+++ b/include/plog/Formatters/TxtFormatter.h
@@ -18,7 +18,7 @@ namespace plog
             util::localtime_s(&t, &record.getTime().time);
 
 			char timeBuffer[32];
-			strftime(timeBuffer, _countof(timeBuffer), "%Y-%m-%d %T", &t);
+			strftime(timeBuffer, sizeof(timeBuffer), "%Y-%m-%d %T", &t);
 
             util::nstringstream ss;
 			ss << timeBuffer << PLOG_NSTR('.') << std::setfill(PLOG_NSTR('0')) << std::setw(3) 

--- a/include/plog/Formatters/TxtFormatter.h
+++ b/include/plog/Formatters/TxtFormatter.h
@@ -18,12 +18,20 @@ namespace plog
             util::localtime_s(&t, &record.getTime().time);
 
             util::nstringstream ss;
-            ss << t.tm_year + 1900 << "-" << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_mon + 1 << "-" << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_mday << " ";
-            ss << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_hour << ":" << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_min << ":" << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_sec << "." << std::setfill(PLOG_NSTR('0')) << std::setw(3) << record.getTime().millitm << " ";
-            ss << std::setfill(PLOG_NSTR(' ')) << std::setw(5) << std::left << getSeverityName(record.getSeverity()) << " ";
-            ss << "[" << record.getTid() << "] ";
-            ss << "[" << record.getFunc().c_str() << "@" << record.getLine() << "] ";
-            ss << record.getMessage().c_str() << "\n";
+            ss << t.tm_year + 1900 << PLOG_NSTR('-') << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_mon + 1
+			   << PLOG_NSTR('-') << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_mday << PLOG_NSTR(' ');
+
+            ss << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_hour << PLOG_NSTR(':') 
+			   << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_min << PLOG_NSTR(':') << std::setfill(PLOG_NSTR('0')) 
+			   << std::setw(2) << t.tm_sec << PLOG_NSTR('.') << std::setfill(PLOG_NSTR('0')) << std::setw(3) 
+			   << record.getTime().millitm << PLOG_NSTR(' ');
+
+            ss << std::setfill(PLOG_NSTR(' ')) << std::setw(5) << std::left << getSeverityName(record.getSeverity()) 
+			   << PLOG_NSTR(' ');
+
+            ss << PLOG_NSTR('[') << record.getTid() << PLOG_NSTR("] ");
+            ss << PLOG_NSTR('[') << record.getFunc().c_str() << PLOG_NSTR('@') << record.getLine() << PLOG_NSTR("] ");
+            ss << record.getMessage().c_str() << PLOG_NSTR('\n');
 
             return ss.str();
         }

--- a/include/plog/Formatters/TxtFormatter.h
+++ b/include/plog/Formatters/TxtFormatter.h
@@ -17,14 +17,14 @@ namespace plog
             tm t;
             util::localtime_s(&t, &record.getTime().time);
 
-			char timeBuffer[32];
-			strftime(timeBuffer, sizeof(timeBuffer), "%Y-%m-%d %T", &t);
+            char timeBuffer[32];
+            strftime(timeBuffer, sizeof(timeBuffer), "%Y-%m-%d %T", &t);
 
             util::nstringstream ss;
-			ss << timeBuffer << PLOG_NSTR('.') << std::setfill(PLOG_NSTR('0')) << std::setw(3) 
-			   << record.getTime().millitm << PLOG_NSTR(' ')
+            ss << timeBuffer << PLOG_NSTR('.') << std::setfill(PLOG_NSTR('0')) << std::setw(3) 
+               << record.getTime().millitm << PLOG_NSTR(' ')
                << std::setfill(PLOG_NSTR(' ')) << std::setw(5) << std::left << getSeverityName(record.getSeverity()) 
-			   << PLOG_NSTR(' ')
+               << PLOG_NSTR(' ')
                << PLOG_NSTR('[') << record.getTid() << PLOG_NSTR("] ")
                << PLOG_NSTR('[') << record.getFunc().c_str() << PLOG_NSTR('@') << record.getLine() << PLOG_NSTR("] ")
                << record.getMessage().c_str() << PLOG_NSTR('\n');

--- a/include/plog/Formatters/TxtFormatter.h
+++ b/include/plog/Formatters/TxtFormatter.h
@@ -17,21 +17,17 @@ namespace plog
             tm t;
             util::localtime_s(&t, &record.getTime().time);
 
+			char timeBuffer[32];
+			strftime(timeBuffer, _countof(timeBuffer), "%Y-%m-%d %T", &t);
+
             util::nstringstream ss;
-            ss << t.tm_year + 1900 << PLOG_NSTR('-') << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_mon + 1
-			   << PLOG_NSTR('-') << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_mday << PLOG_NSTR(' ');
-
-            ss << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_hour << PLOG_NSTR(':') 
-			   << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_min << PLOG_NSTR(':') << std::setfill(PLOG_NSTR('0')) 
-			   << std::setw(2) << t.tm_sec << PLOG_NSTR('.') << std::setfill(PLOG_NSTR('0')) << std::setw(3) 
-			   << record.getTime().millitm << PLOG_NSTR(' ');
-
-            ss << std::setfill(PLOG_NSTR(' ')) << std::setw(5) << std::left << getSeverityName(record.getSeverity()) 
-			   << PLOG_NSTR(' ');
-
-            ss << PLOG_NSTR('[') << record.getTid() << PLOG_NSTR("] ");
-            ss << PLOG_NSTR('[') << record.getFunc().c_str() << PLOG_NSTR('@') << record.getLine() << PLOG_NSTR("] ");
-            ss << record.getMessage().c_str() << PLOG_NSTR('\n');
+			ss << timeBuffer << PLOG_NSTR('.') << std::setfill(PLOG_NSTR('0')) << std::setw(3) 
+			   << record.getTime().millitm << PLOG_NSTR(' ')
+               << std::setfill(PLOG_NSTR(' ')) << std::setw(5) << std::left << getSeverityName(record.getSeverity()) 
+			   << PLOG_NSTR(' ')
+               << PLOG_NSTR('[') << record.getTid() << PLOG_NSTR("] ")
+               << PLOG_NSTR('[') << record.getFunc().c_str() << PLOG_NSTR('@') << record.getLine() << PLOG_NSTR("] ")
+               << record.getMessage().c_str() << PLOG_NSTR('\n');
 
             return ss.str();
         }

--- a/include/plog/Severity.h
+++ b/include/plog/Severity.h
@@ -14,24 +14,24 @@ namespace plog
         verbose = 6
     };
 
-	inline util::nstring::const_pointer getSeverityName(Severity severity)
-	{
-		switch (severity)
-		{
-		case fatal:
-			return PLOG_NSTR("FATAL");
-		case error:
-			return PLOG_NSTR("ERROR");
-		case warning:
-			return PLOG_NSTR("WARN");
-		case info:
-			return PLOG_NSTR("INFO");
-		case debug:
-			return PLOG_NSTR("DEBUG");
-		case verbose:
-			return PLOG_NSTR("VERB");
-		default:
-			return PLOG_NSTR("NONE");
-		}
-	}
+    inline util::nstring::const_pointer getSeverityName(Severity severity)
+    {
+        switch (severity)
+        {
+        case fatal:
+            return PLOG_NSTR("FATAL");
+        case error:
+            return PLOG_NSTR("ERROR");
+        case warning:
+            return PLOG_NSTR("WARN");
+        case info:
+            return PLOG_NSTR("INFO");
+        case debug:
+            return PLOG_NSTR("DEBUG");
+        case verbose:
+            return PLOG_NSTR("VERB");
+        default:
+            return PLOG_NSTR("NONE");
+        }
+    }
 }

--- a/include/plog/Severity.h
+++ b/include/plog/Severity.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Util.h"
 
 namespace plog
 {
@@ -12,25 +13,25 @@ namespace plog
         debug = 5,
         verbose = 6
     };
-        
-    inline const char* getSeverityName(Severity severity)
-    {
-        switch (severity)
-        {
-        case fatal:
-            return "FATAL";
-        case error:
-            return "ERROR";
-        case warning:
-            return "WARN";
-        case info:
-            return "INFO";
-        case debug:
-            return "DEBUG";
-        case verbose:
-            return "VERB";
-        default:
-            return "NONE";
-        }
-    }
+
+	inline util::nstring::const_pointer getSeverityName(Severity severity)
+	{
+		switch (severity)
+		{
+		case fatal:
+			return PLOG_NSTR("FATAL");
+		case error:
+			return PLOG_NSTR("ERROR");
+		case warning:
+			return PLOG_NSTR("WARN");
+		case info:
+			return PLOG_NSTR("INFO");
+		case debug:
+			return PLOG_NSTR("DEBUG");
+		case verbose:
+			return PLOG_NSTR("VERB");
+		default:
+			return PLOG_NSTR("NONE");
+		}
+	}
 }

--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -295,12 +295,19 @@ namespace plog
             friend class MutexLock;
 
         private:
+            enum { PTHREAD_SPINLOCK_COUNT = 500 };
+
             void lock()
             {
 #ifdef _WIN32
                 ::EnterCriticalSection(&m_sync);
 #else
-                ::pthread_mutex_lock(&m_sync);
+                bool isLocked = false;
+                for (unsigned i=0; i<PTHREAD_SPINLOCK_COUNT && !isLocked; ++i,pthread_yield())
+                    isLocked = ::pthread_mutex_trylock(&m_sync) == 0;
+
+                if (!isLocked)
+                    ::pthread_mutex_lock(&m_sync);
 #endif
             }
 


### PR DESCRIPTION
Hello,

I've tried this logger and found it pretty light and useful. However, I've found multi-threading concurrency bottleneck, so I'd like to improve this a bit.
Test code sample and benchmarking result will be provided below. 
1. Mutex lock is not necessary when performing line formatting and conversion to UTF-8, so I have moved string manipulation out of the locked scope. This gave more concurrency level and about 3 times more performance on Windows with my test sample. Unfortunately, this change won't improve things on Linux. 
2. Investigating at Linux I've found that application is still running "in one thread". Profiler shows spending a lot of time for mutex lock/unlock, not for disk IO. The problem is inside pthread_mutex_lock, which has too small spinlock iterations count before entering sleep state. I've added spinlock iterations manually, so code became parallel and 3 times faster in my sample in Linux too.
3. Omitting several ANSI/UTF-16 conversions and changing 'stream << char[1]' to 'stream << char' gave me another few percent of performance. This just removes redundant strlen() call on char[1]. Additionally strftime is about 30% faster on Windows than manual stringstream conversion, and it looks simpler.
## Multithreading test code

``` C++
    void threadFunction()
    {
        for (int i = 0; i < 800000; ++i)
            LOG(plog::debug) << "i=" << i << "clock:" << clock();
    }

    int main(int argc, char* argv[])
    {
        plog::init(plog::debug, "Hello.txt");
        std::vector<std::thread> threads(4);

        clock_t start = clock();

        for (size_t i = 0; i < threads.size(); ++i)
            threads[i] = std::thread(threadFunction);

        for (std::thread& thread : threads)
            thread.join();

        clock_t finish = clock();

        std::cout << "Time: " << finish - start << std::endl;

        return 0;
    }
```
## Benchmarking results for Linux

Test system is Core i5-4300M with SSD. OS: Windows 10 host, VM: Unubtu Linux 14.04.2. 
### Original branch

**top/iotop results: Disk write speed 4-5 MB/s, CPU 25-30% total (one core at 100%).**

```
  victor@ubuntu:~/plog$ time ./test_master_o2
  Time: 106639234

  real  0m58.393s
  user  0m4.579s
  sys   1m42.063s
```
### Performance improvement branch

**top/iotop results: Disk write speed 17-22 MB/s, CPU 100% total**

```
  victor@ubuntu:~/plog$ time ./test_perf_o2_3
  Time: 39805657

  real  0m11.434s
  user  0m16.325s
  sys   0m23.483s
```

Benchmarking results for Windows are very similar.

Thanks for review and feel free to ask additional questions if needed. 
Victor.
