### PR TITLE
Modify default instance number

### DIFF
--- a/include/plog/Compatibility.h
+++ b/include/plog/Compatibility.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <plog/Default.h>
 
 //////////////////////////////////////////////////////////////////////////
 // This file provides backward compatibility with the old version of plog.
@@ -38,8 +39,8 @@ namespace plog
     }
 
     template<class CharType>
-    inline Logger<0>& init(const CharType* fileName, Severity maxSeverity, size_t maxFileSize = 0, int maxFiles = 0)
+    inline Logger<PLOG_DEFAULT_INSTANCE>& init(const CharType* fileName, Severity maxSeverity, size_t maxFileSize = 0, int maxFiles = 0)
     {
-        return init<0>(maxSeverity, fileName, maxFileSize, maxFiles);
+        return init<PLOG_DEFAULT_INSTANCE>(maxSeverity, fileName, maxFileSize, maxFiles);
     }
 }

--- a/include/plog/Compatibility.h
+++ b/include/plog/Compatibility.h
@@ -23,13 +23,13 @@ namespace plog
     template<class CharType>
     inline void init_csv(const CharType* fileName, Severity maxSeverity)
     {
-        init<CsvFormatter, 0>(maxSeverity, fileName);
+        init<CsvFormatter, PLOG_DEFAULT_INSTANCE>(maxSeverity, fileName);
     }
 
     template<class CharType>
     inline void init_txt(const CharType* fileName, Severity maxSeverity)
     {
-        init<TxtFormatter, 0>(maxSeverity, fileName);
+        init<TxtFormatter, PLOG_DEFAULT_INSTANCE>(maxSeverity, fileName);
     }
 
     template<int instance, class CharType>

--- a/include/plog/Default.h
+++ b/include/plog/Default.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifndef PLOG_DEFAULT_INSTANCE
+  #define PLOG_DEFAULT_INSTANCE 0
+#endif

--- a/include/plog/Init.h
+++ b/include/plog/Init.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstring>
+#include <plog/Default.h>
 #include <plog/Logger.h>
 #include <plog/Formatters/CsvFormatter.h>
 #include <plog/Formatters/TxtFormatter.h>
@@ -30,9 +31,9 @@ namespace plog
         return appender ? logger.addAppender(appender) : logger;
     }
 
-    inline Logger<0>& init(Severity maxSeverity = none, IAppender* appender = NULL)
+    inline Logger<PLOG_DEFAULT_INSTANCE>& init(Severity maxSeverity = none, IAppender* appender = NULL)
     {
-        return init<0>(maxSeverity, appender);
+        return init<PLOG_DEFAULT_INSTANCE>(maxSeverity, appender);
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -46,7 +47,7 @@ namespace plog
     }
 
     template<class Formatter>
-    inline Logger<0>& init(Severity maxSeverity, const util::nchar* fileName, size_t maxFileSize = 0, int maxFiles = 0)
+    inline Logger<PLOG_DEFAULT_INSTANCE>& init(Severity maxSeverity, const util::nchar* fileName, size_t maxFileSize = 0, int maxFiles = 0)
     {
         return init<Formatter, 0>(maxSeverity, fileName, maxFileSize, maxFiles);
     }
@@ -60,9 +61,9 @@ namespace plog
         return isCsv(fileName) ? init<CsvFormatter, instance>(maxSeverity, fileName, maxFileSize, maxFiles) : init<TxtFormatter, instance>(maxSeverity, fileName, maxFileSize, maxFiles);
     }
 
-    inline Logger<0>& init(Severity maxSeverity, const util::nchar* fileName, size_t maxFileSize = 0, int maxFiles = 0)
+    inline Logger<PLOG_DEFAULT_INSTANCE>& init(Severity maxSeverity, const util::nchar* fileName, size_t maxFileSize = 0, int maxFiles = 0)
     {
-        return init<0>(maxSeverity, fileName, maxFileSize, maxFiles);
+        return init<PLOG_DEFAULT_INSTANCE>(maxSeverity, fileName, maxFileSize, maxFiles);
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -76,7 +77,7 @@ namespace plog
     }
 
     template<class Formatter>
-    inline Logger<0>& init(Severity maxSeverity, const char* fileName, size_t maxFileSize = 0, int maxFiles = 0)
+    inline Logger<PLOG_DEFAULT_INSTANCE>& init(Severity maxSeverity, const char* fileName, size_t maxFileSize = 0, int maxFiles = 0)
     {
         return init<Formatter, 0>(maxSeverity, fileName, maxFileSize, maxFiles);
     }
@@ -87,9 +88,9 @@ namespace plog
         return init<instance>(maxSeverity, util::toWide(fileName).c_str(), maxFileSize, maxFiles);
     }
 
-    inline Logger<0>& init(Severity maxSeverity, const char* fileName, size_t maxFileSize = 0, int maxFiles = 0)
+    inline Logger<PLOG_DEFAULT_INSTANCE>& init(Severity maxSeverity, const char* fileName, size_t maxFileSize = 0, int maxFiles = 0)
     {
-        return init<0>(maxSeverity, fileName, maxFileSize, maxFiles);
+        return init<PLOG_DEFAULT_INSTANCE>(maxSeverity, fileName, maxFileSize, maxFiles);
     }
 #endif
 }

--- a/include/plog/Init.h
+++ b/include/plog/Init.h
@@ -49,7 +49,7 @@ namespace plog
     template<class Formatter>
     inline Logger<PLOG_DEFAULT_INSTANCE>& init(Severity maxSeverity, const util::nchar* fileName, size_t maxFileSize = 0, int maxFiles = 0)
     {
-        return init<Formatter, 0>(maxSeverity, fileName, maxFileSize, maxFiles);
+        return init<Formatter, PLOG_DEFAULT_INSTANCE>(maxSeverity, fileName, maxFileSize, maxFiles);
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -79,7 +79,7 @@ namespace plog
     template<class Formatter>
     inline Logger<PLOG_DEFAULT_INSTANCE>& init(Severity maxSeverity, const char* fileName, size_t maxFileSize = 0, int maxFiles = 0)
     {
-        return init<Formatter, 0>(maxSeverity, fileName, maxFileSize, maxFiles);
+        return init<Formatter, PLOG_DEFAULT_INSTANCE>(maxSeverity, fileName, maxFileSize, maxFiles);
     }
 
     template<int instance>

--- a/include/plog/Log.h
+++ b/include/plog/Log.h
@@ -4,6 +4,7 @@
 //  License: MPL 2.0, http://mozilla.org/MPL/2.0/
 
 #pragma once
+#include <plog/Default.h>
 #include <plog/Record.h>
 #include <plog/Logger.h>
 #include <plog/Init.h>
@@ -28,13 +29,13 @@
 // Log severity level checker
 
 #define IF_LOG_(instance, severity)     if (plog::get<instance>() && plog::get<instance>()->checkSeverity(severity))
-#define IF_LOG(severity)                IF_LOG_(0, severity)
+#define IF_LOG(severity)                IF_LOG_(PLOG_DEFAULT_INSTANCE, severity)
 
 //////////////////////////////////////////////////////////////////////////
 // Main logging macros
 
 #define LOG_(instance, severity)        IF_LOG_(instance, severity) (*plog::get<instance>()) += plog::Record(severity, PLOG_GET_FUNC(), __LINE__, PLOG_GET_THIS())
-#define LOG(severity)                   LOG_(0, severity)
+#define LOG(severity)                   LOG_(PLOG_DEFAULT_INSTANCE, severity)
 
 #define LOG_VERBOSE                     LOG(plog::verbose)
 #define LOG_DEBUG                       LOG(plog::debug)
@@ -68,7 +69,7 @@
 // Conditional logging macros
 
 #define LOG_IF_(instance, severity, condition)  if (condition) LOG_(instance, severity)
-#define LOG_IF(severity, condition)             LOG_IF_(0, severity, condition)
+#define LOG_IF(severity, condition)             LOG_IF_(PLOG_DEFAULT_INSTANCE, severity, condition)
 
 #define LOG_VERBOSE_IF(condition)               LOG_IF(plog::verbose, condition)
 #define LOG_DEBUG_IF(condition)                 LOG_IF(plog::debug, condition)

--- a/include/plog/Logger.h
+++ b/include/plog/Logger.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <plog/Default.h>
 #include <plog/Appenders/IAppender.h>
 #include <plog/Util.h>
 
@@ -62,8 +63,8 @@ namespace plog
         return Logger<instance>::getInstance();
     }
 
-    inline Logger<0>* get()
+    inline Logger<PLOG_DEFAULT_INSTANCE>* get()
     {
-        return Logger<0>::getInstance();
+        return Logger<PLOG_DEFAULT_INSTANCE>::getInstance();
     }
 }


### PR DESCRIPTION
Hi,

This PR simply gives the ability to change the default logger. This should make it easier to support the issue I had in #10 . The idea is, I can simply add `-DPLOG_DEFAULT_INSTANCE=5` to the cppflags for the library and I don't have to do things like `LOGD_(5) << "HI"` - I can keep the nice syntax of `LOGD << "HI"`.

If `PLOG_DEFAULT_INSTANCE` isn't defined, it will default to 0.

Thoughts?