### PR TITLE
Don't use the __OBJC__ compiler flag.

### DIFF
--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -143,11 +143,13 @@ namespace plog
 
         inline std::string processFuncName(const char* func)
         {
-#if (defined(_WIN32) && !defined(__MINGW32__)) || defined(__OBJC__)
-            return std::string(func);
-#else
             const char* funcBegin = func;
             const char* funcEnd = ::strchr(funcBegin, '(');
+
+            if (!funcEnd)
+            {
+                return std::string(func);
+            }
 
             for (const char* i = funcEnd - 1; i >= funcBegin; --i)
             {
@@ -159,7 +161,6 @@ namespace plog
             }
 
             return std::string(funcBegin, funcEnd);
-#endif
         }
 
         inline const nchar* findExtensionDot(const nchar* fileName)


### PR DESCRIPTION
Being a header-only library, this causes crashes on cross objc++/c++ projects.
In particular, a logger created in c++ will call processFuncName (Util.h) on an objc++ function name
and segfault because the assumed characters are missing.

This particular fix just removes the processing done on non-objc, non-mingw32-win32 function names.
This is good because it disambiguates overloaded functions (we'll consider the return type a bonus too).
This is bad because it makes logs bigger.