### PR TITLE
add MutexedConsoleAppender

### DIFF
--- a/include/plog/Appenders/MutexedConsoleAppender.h
+++ b/include/plog/Appenders/MutexedConsoleAppender.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "ConsoleAppender.h"
+#include <mutex>
+
+namespace plog
+{
+    template<class Formatter>
+    class MutexedConsoleAppender : public ConsoleAppender<Formatter>
+    {
+    public:
+        MutexedConsoleAppender(std::mutex& mutex) : m_mutex(mutex) {}
+
+        virtual void write(const Record& record)
+        {
+            m_mutex.lock();
+            plog::ConsoleAppender<Formatter>::write(record);
+            m_mutex.unlock();
+        }
+
+    protected:
+        std::mutex& m_mutex;
+    };
+}


### PR DESCRIPTION
ConsoleAppender, at some level, depends on the threading guarantees std::cout gives.
Before C++11, there is no threading model, so there are no guarantees.
After C++11, std::cout guarantees no races.
Whatever this means, it's easy enough to get interleaved logs on OSX.
For example, if "apple" is logged in one thread, and "ORANGE" in another, you might get "OaRpApNlGeE".

MutexedConsoleAppender takes a C++11 mutex and locks it around writing, solving the interleaving problem.
There's probably a performance drawback.