### PR TITLE
Fix incorrect platform line endings being written to files

### DIFF
--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -209,11 +209,11 @@ namespace plog
         class File : NonCopyable
         {
         public:
-            File() : m_file(-1)
+            File(bool binary = false) : m_file(-1), m_binary(binary)
             {
             }
 
-            File(const nchar* fileName) : m_file(-1)
+            File(const nchar* fileName, bool binary = false) : m_file(-1), m_binary(binary)
             {
                 open(fileName);
             }
@@ -226,9 +226,9 @@ namespace plog
             off_t open(const nchar* fileName)
             {
 #if defined(_WIN32) && (defined(__BORLANDC__) || defined(__MINGW32__))
-                m_file = ::_wsopen(fileName, _O_CREAT | _O_WRONLY | _O_BINARY, SH_DENYWR, _S_IREAD | _S_IWRITE);
+                m_file = ::_wsopen(fileName, _O_CREAT | _O_WRONLY | (m_binary ? _O_BINARY: 0), SH_DENYWR, _S_IREAD | _S_IWRITE);
 #elif defined(_WIN32)
-                ::_wsopen_s(&m_file, fileName, _O_CREAT | _O_WRONLY | _O_BINARY, _SH_DENYWR, _S_IREAD | _S_IWRITE);
+                ::_wsopen_s(&m_file, fileName, _O_CREAT | _O_WRONLY | (m_binary ? _O_BINARY : 0), _SH_DENYWR, _S_IREAD | _S_IWRITE);
 #else
                 m_file = ::open(fileName, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 #endif
@@ -292,6 +292,7 @@ namespace plog
 
         private:
             int m_file;
+            bool m_binary;
         };
 
         class Mutex : NonCopyable

--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -209,11 +209,11 @@ namespace plog
         class File : NonCopyable
         {
         public:
-            File(bool binary = false) : m_file(-1), m_binary(binary)
+            File(bool binary = false) : m_file(NULL), m_binary(binary)
             {
             }
 
-            File(const nchar* fileName, bool binary = false) : m_file(-1), m_binary(binary)
+            File(const nchar* fileName, bool binary = false) : m_file(NULL), m_binary(binary)
             {
                 open(fileName);
             }
@@ -225,23 +225,33 @@ namespace plog
 
             off_t open(const nchar* fileName)
             {
-#if defined(_WIN32) && (defined(__BORLANDC__) || defined(__MINGW32__))
-                m_file = ::_wsopen(fileName, _O_CREAT | _O_WRONLY | (m_binary ? _O_BINARY: 0), SH_DENYWR, _S_IREAD | _S_IWRITE);
-#elif defined(_WIN32)
-                ::_wsopen_s(&m_file, fileName, _O_CREAT | _O_WRONLY | (m_binary ? _O_BINARY : 0), _SH_DENYWR, _S_IREAD | _S_IWRITE);
+#if defined (_WIN32)
+				const nchar* mode = m_binary ? L"ab" : L"a";
 #else
-                m_file = ::open(fileName, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+				const nchar* mode = m_binary ? "ab" : "a";
+#endif
+#if defined(_WIN32) && (defined(__BORLANDC__) || defined(__MINGW32__))
+                m_file = fopen(fileName, mode);
+#elif defined(_WIN32)
+                m_file = _wfsopen(fileName, mode, _SH_DENYNO);
+#else
+                m_file = fopen(fileName, mode);
 #endif
                 return seek(0, SEEK_END);
             }
 
             int write(const void* buf, size_t count)
             {
-#ifdef _WIN32
-                return m_file != -1 ? ::_write(m_file, buf, static_cast<unsigned int>(count)) : -1;
-#else
-                return m_file != -1 ? static_cast<int>(::write(m_file, buf, count)) : -1;
-#endif
+                if (m_file != NULL)
+                {
+                    size_t bytes_written = fwrite(buf, 1, static_cast<unsigned int>(count), m_file);
+                    fflush(m_file);
+                    return static_cast<int>(bytes_written);
+                }
+                else
+                {
+                    return -1;
+                }
             }
 
             template<class CharType>
@@ -252,23 +262,15 @@ namespace plog
 
             off_t seek(off_t offset, int whence)
             {
-#ifdef _WIN32
-                return m_file != -1 ? ::_lseek(m_file, offset, whence) : -1;
-#else
-                return m_file != -1 ? ::lseek(m_file, offset, whence) : -1;
-#endif
+                return m_file != NULL ? fseek(m_file, offset, whence) : -1;
             }
 
             void close()
             {
-                if (m_file != -1)
+                if (m_file != NULL)
                 {
-#ifdef _WIN32
-                    ::_close(m_file);
-#else
-                    ::close(m_file);
-#endif
-                    m_file = -1;
+                    fclose(m_file);
+                    m_file = NULL;
                 }
             }
 
@@ -291,7 +293,7 @@ namespace plog
             }
 
         private:
-            int m_file;
+            FILE* m_file;
             bool m_binary;
         };
 


### PR DESCRIPTION
When logging to files in Windows '\n' was written as the newline seperator. Since the native line endings on Windows is \r\n this made the logs show up without visible newlines in many Windows applications (such as notepad).

This PR fixes this by opening the log files in text mode instead of binary by default. This makes the runtime translate the \n into the native line ending for the current platform.