### PR TITLE
Get the thread id on macOS 10.12 Sierra without using the now deprecated syscall(2)

### DIFF
--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -86,7 +86,18 @@ namespace plog
 #elif defined(__unix__)
             return static_cast<unsigned int>(::syscall(__NR_gettid));
 #elif defined(__APPLE__)
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12
+            //pid_t tid = 0;
+            uint64_t tid64;
+            pthread_threadid_np(NULL, &tid64);
+            //tid = (pid_t)tid64;
+            return static_cast<unsigned int>(tid64);
+#else
             return static_cast<unsigned int>(::syscall(SYS_thread_selfid));
+#endif
+
+
+
 #endif
         }
 

--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -93,9 +93,6 @@ namespace plog
 #else
             return static_cast<unsigned int>(::syscall(SYS_thread_selfid));
 #endif
-
-
-
 #endif
         }
 

--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -87,9 +87,11 @@ namespace plog
             return static_cast<unsigned int>(::syscall(__NR_gettid));
 #elif defined(__APPLE__)
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12
-            uint64_t tid64;
-            pthread_threadid_np(NULL, &tid64);
-            return static_cast<unsigned int>(tid64);
+            {
+              uint64_t tid64;
+              pthread_threadid_np(NULL, &tid64);
+              return static_cast<unsigned int>(tid64);
+            }
 #else
             return static_cast<unsigned int>(::syscall(SYS_thread_selfid));
 #endif

--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -86,15 +86,9 @@ namespace plog
 #elif defined(__unix__)
             return static_cast<unsigned int>(::syscall(__NR_gettid));
 #elif defined(__APPLE__)
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12
-            {
-              uint64_t tid64;
-              pthread_threadid_np(NULL, &tid64);
-              return static_cast<unsigned int>(tid64);
-            }
-#else
-            return static_cast<unsigned int>(::syscall(SYS_thread_selfid));
-#endif
+            uint64_t tid64;
+            pthread_threadid_np(NULL, &tid64);
+            return static_cast<unsigned int>(tid64);
 #endif
         }
 

--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -87,10 +87,8 @@ namespace plog
             return static_cast<unsigned int>(::syscall(__NR_gettid));
 #elif defined(__APPLE__)
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12
-            //pid_t tid = 0;
             uint64_t tid64;
             pthread_threadid_np(NULL, &tid64);
-            //tid = (pid_t)tid64;
             return static_cast<unsigned int>(tid64);
 #else
             return static_cast<unsigned int>(::syscall(SYS_thread_selfid));


### PR DESCRIPTION
On macOS 10.12 (Sierra) syscall(2) has been deprecated. The result is that using plog as-is produces a deprecation warning for every source file including plog.

This pull request deals with that.