### PR TITLE
Update UTF8Converter.h

### DIFF
--- a/include/plog/Converters/UTF8Converter.h
+++ b/include/plog/Converters/UTF8Converter.h
@@ -13,7 +13,7 @@ namespace plog
             return std::string(kBOM) + convert(str);
         }
 
-#ifdef WIN32
+#ifdef _WIN32
         static std::string convert(const util::nstring& str)
         {
             return util::toUTF8(str);


### PR DESCRIPTION
fix WIN32=>_WIN32

I couldn't build x64 project using VSC++ 2015.