### PR TITLE
Add missing macros for logging with severity NONE

### DIFF
--- a/include/plog/Log.h
+++ b/include/plog/Log.h
@@ -48,6 +48,7 @@
 #define LOG_WARNING                     LOG(plog::warning)
 #define LOG_ERROR                       LOG(plog::error)
 #define LOG_FATAL                       LOG(plog::fatal)
+#define LOG_NONE                        LOG(plog::none)
 
 #define LOG_VERBOSE_(instance)          LOG_(instance, plog::verbose)
 #define LOG_DEBUG_(instance)            LOG_(instance, plog::debug)
@@ -55,6 +56,7 @@
 #define LOG_WARNING_(instance)          LOG_(instance, plog::warning)
 #define LOG_ERROR_(instance)            LOG_(instance, plog::error)
 #define LOG_FATAL_(instance)            LOG_(instance, plog::fatal)
+#define LOG_NONE_(instance)             LOG_(instance, plog::none)
 
 #define LOGV                            LOG_VERBOSE
 #define LOGD                            LOG_DEBUG
@@ -62,6 +64,7 @@
 #define LOGW                            LOG_WARNING
 #define LOGE                            LOG_ERROR
 #define LOGF                            LOG_FATAL
+#define LOGN                            LOG_NONE
 
 #define LOGV_(instance)                 LOG_VERBOSE_(instance)
 #define LOGD_(instance)                 LOG_DEBUG_(instance)
@@ -69,6 +72,7 @@
 #define LOGW_(instance)                 LOG_WARNING_(instance)
 #define LOGE_(instance)                 LOG_ERROR_(instance)
 #define LOGF_(instance)                 LOG_FATAL_(instance)
+#define LOGN_(instance)                 LOG_NONE_(instance)
 
 //////////////////////////////////////////////////////////////////////////
 // Conditional logging macros
@@ -82,6 +86,7 @@
 #define LOG_WARNING_IF(condition)               LOG_IF(plog::warning, condition)
 #define LOG_ERROR_IF(condition)                 LOG_IF(plog::error, condition)
 #define LOG_FATAL_IF(condition)                 LOG_IF(plog::fatal, condition)
+#define LOG_NONE_IF(condition)                  LOG_IF(plog::none, condition)
 
 #define LOG_VERBOSE_IF_(instance, condition)    LOG_IF_(instance, plog::verbose, condition)
 #define LOG_DEBUG_IF_(instance, condition)      LOG_IF_(instance, plog::debug, condition)
@@ -89,6 +94,7 @@
 #define LOG_WARNING_IF_(instance, condition)    LOG_IF_(instance, plog::warning, condition)
 #define LOG_ERROR_IF_(instance, condition)      LOG_IF_(instance, plog::error, condition)
 #define LOG_FATAL_IF_(instance, condition)      LOG_IF_(instance, plog::fatal, condition)
+#define LOG_NONE_IF_(instance, condition)       LOG_IF_(instance, plog::none, condition)
 
 #define LOGV_IF(condition)                      LOG_VERBOSE_IF(condition)
 #define LOGD_IF(condition)                      LOG_DEBUG_IF(condition)
@@ -96,6 +102,7 @@
 #define LOGW_IF(condition)                      LOG_WARNING_IF(condition)
 #define LOGE_IF(condition)                      LOG_ERROR_IF(condition)
 #define LOGF_IF(condition)                      LOG_FATAL_IF(condition)
+#define LOGN_IF(condition)                      LOG_NONE_IF(condition)
 
 #define LOGV_IF_(instance, condition)           LOG_VERBOSE_IF_(instance, condition)
 #define LOGD_IF_(instance, condition)           LOG_DEBUG_IF_(instance, condition)
@@ -103,3 +110,4 @@
 #define LOGW_IF_(instance, condition)           LOG_WARNING_IF_(instance, condition)
 #define LOGE_IF_(instance, condition)           LOG_ERROR_IF_(instance, condition)
 #define LOGF_IF_(instance, condition)           LOG_FATAL_IF_(instance, condition)
+#define LOGN_IF_(instance, condition)           LOG_NONE_IF_(instance, condition)


### PR DESCRIPTION
I want to have some log messages independent of the severity. Saw that the severity level 'NONE' is the right type for this. But the macros are missing. This patch will provide this macros.