### PR TITLE
Removed forced wide string on Windows

### DIFF
--- a/include/plog/Appenders/ConsoleAppender.h
+++ b/include/plog/Appenders/ConsoleAppender.h
@@ -33,7 +33,7 @@ namespace plog
     protected:
         void writestr(const util::nstring& str)
         {
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
             if (m_isatty)
             {
                 WriteConsoleW(m_stdoutHandle, str.c_str(), static_cast<DWORD>(str.size()), NULL, NULL);

--- a/include/plog/Appenders/RollingFileAppender.h
+++ b/include/plog/Appenders/RollingFileAppender.h
@@ -19,7 +19,7 @@ namespace plog
             util::splitFileName(fileName, m_fileNameNoExt, m_fileExt);
         }
 
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
         RollingFileAppender(const char* fileName, size_t maxFileSize = 0, int maxFiles = 0)
             : m_fileSize()
             , m_maxFileSize((std::max)(static_cast<off_t>(maxFileSize), static_cast<off_t>(1000))) // set a lower limit for the maxFileSize

--- a/include/plog/Converters/NativeEOLConverter.h
+++ b/include/plog/Converters/NativeEOLConverter.h
@@ -7,7 +7,7 @@ namespace plog
     template<class NextConverter = UTF8Converter>
     class NativeEOLConverter : public NextConverter
     {
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
     public:
         static std::string header(const util::nstring& str)
         {

--- a/include/plog/Converters/UTF8Converter.h
+++ b/include/plog/Converters/UTF8Converter.h
@@ -13,7 +13,7 @@ namespace plog
             return std::string(kBOM) + convert(str);
         }
 
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
         static std::string convert(const util::nstring& str)
         {
             return util::toNarrow(str, codePage::kUTF8);

--- a/include/plog/Init.h
+++ b/include/plog/Init.h
@@ -12,7 +12,7 @@ namespace plog
         bool isCsv(const util::nchar* fileName)
         {
             const util::nchar* dot = util::findExtensionDot(fileName);
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
             return dot && 0 == std::wcscmp(dot, L".csv");
 #else
             return dot && 0 == std::strcmp(dot, ".csv");
@@ -68,7 +68,7 @@ namespace plog
     //////////////////////////////////////////////////////////////////////////
     // CHAR variants for Windows
 
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
     template<class Formatter, int instance>
     inline Logger<instance>& init(Severity maxSeverity, const char* fileName, size_t maxFileSize = 0, int maxFiles = 0)
     {

--- a/include/plog/Record.h
+++ b/include/plog/Record.h
@@ -17,9 +17,9 @@ namespace plog
         {
             data = data ? data : "(null)";
 
-#if defined(_WIN32) && defined(__BORLANDC__)
+#if defined(_WIN32) && defined(__BORLANDC__) && PLOG_ENABLE_WCHAR_INPUT
             stream << util::toWide(data);
-#elif defined(_WIN32)
+#elif defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
             std::operator<<(stream, util::toWide(data));
 #else
             std::operator<<(stream, data);
@@ -76,7 +76,7 @@ namespace plog
         }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
         Record& operator<<(std::wostream& (*data)(std::wostream&))
 #else
         Record& operator<<(std::ostream& (*data)(std::ostream&))
@@ -89,7 +89,7 @@ namespace plog
 #ifdef QT_VERSION
         Record& operator<<(const QString& data)
         {
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
             return *this << data.toStdWString();
 #else
             return *this << data.toStdString();

--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -6,14 +6,6 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
-#ifndef PLOG_ENABLE_WCHAR_INPUT
-#   ifdef _WIN32
-#       define PLOG_ENABLE_WCHAR_INPUT 1
-#   else
-#       define PLOG_ENABLE_WCHAR_INPUT 0
-#   endif
-#endif
-
 #ifdef _WIN32
 #   include <plog/WinApi.h>
 #   include <time.h>
@@ -30,7 +22,7 @@
 #   endif
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
 #   define _PLOG_NSTR(x)   L##x
 #   define PLOG_NSTR(x)    _PLOG_NSTR(x)
 #else
@@ -41,7 +33,7 @@ namespace plog
 {
     namespace util
     {
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
         typedef std::wstring nstring;
         typedef std::wostringstream nostringstream;
         typedef std::wistringstream nistringstream;
@@ -127,7 +119,7 @@ namespace plog
         }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
         inline std::wstring toWide(const char* str)
         {
             size_t len = ::strlen(str);
@@ -184,7 +176,7 @@ namespace plog
 
         inline const nchar* findExtensionDot(const nchar* fileName)
         {
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
             return std::wcsrchr(fileName, L'.');
 #else
             return std::strrchr(fileName, '.');
@@ -238,9 +230,9 @@ namespace plog
 
             off_t open(const nchar* fileName)
             {
-#if defined(_WIN32) && (defined(__BORLANDC__) || defined(__MINGW32__))
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT && (defined(__BORLANDC__) || defined(__MINGW32__))
                 m_file = ::_wsopen(fileName, _O_CREAT | _O_WRONLY | _O_BINARY, SH_DENYWR, _S_IREAD | _S_IWRITE);
-#elif defined(_WIN32)
+#elif defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
                 ::_wsopen_s(&m_file, fileName, _O_CREAT | _O_WRONLY | _O_BINARY, _SH_DENYWR, _S_IREAD | _S_IWRITE);
 #else
                 m_file = ::open(fileName, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
@@ -287,7 +279,7 @@ namespace plog
 
             static int unlink(const nchar* fileName)
             {
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
                 return ::_wunlink(fileName);
 #else
                 return ::unlink(fileName);
@@ -296,7 +288,7 @@ namespace plog
 
             static int rename(const nchar* oldFilename, const nchar* newFilename)
             {
-#ifdef _WIN32
+#if defined(_WIN32) && PLOG_ENABLE_WCHAR_INPUT
                 return MoveFileW(oldFilename, newFilename);
 #else
                 return ::rename(oldFilename, newFilename);


### PR DESCRIPTION
We had issues using the same code (custom operators) across platforms because of the forced use of wide string. Rather let's enable it if we wish to use it. 

Tested your samples after the change, and they build on both Windows and Linux.