### PR TITLE
Add RTEMS support

### DIFF
--- a/include/plog/Log.h
+++ b/include/plog/Log.h
@@ -10,7 +10,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Helper macros that get context info
 
-#if _MSC_VER >= 1600 && !defined(__INTELLISENSE__) && !defined(__INTEL_COMPILER) // >= Visual Studio 2010, skip IntelliSense and Intel Compiler
+#if defined(_MSC_VER) && _MSC_VER >= 1600 && !defined(__INTELLISENSE__) && !defined(__INTEL_COMPILER) // >= Visual Studio 2010, skip IntelliSense and Intel Compiler
 #   define PLOG_GET_THIS()      __if_exists(this) { this } __if_not_exists(this) { 0 }
 #else
 #   define PLOG_GET_THIS()      0
@@ -24,7 +24,7 @@
 #   define PLOG_GET_FUNC()      __PRETTY_FUNCTION__
 #endif
 
-#if PLOG_CAPTURE_FILE
+#ifdef PLOG_CAPTURE_FILE
 #   define PLOG_GET_FILE()      __FILE__
 #else
 #   define PLOG_GET_FILE()      ""


### PR DESCRIPTION
We started to use plog in a project which uses multiple OSes among them RTEMS. 
The port was pretty straight forward. In case you don't mind supporting RTEMS upstream this commit adds the necessary includes and defnitions for the mutex.

It also fixed a few warnings due to missing defines.