### PR TITLE
invert IF_LOG_ logic to avoid dangling else problem 

### DIFF
--- a/include/plog/Log.h
+++ b/include/plog/Log.h
@@ -33,7 +33,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Log severity level checker
 
-#define IF_LOG_(instance, severity)     if (!plog::get<instance>() || !plog::get<instance>()->checkSeverity(severity)) {;} else
+#define IF_LOG_(instance, severity)     if (plog::get<instance>() && plog::get<instance>()->checkSeverity(severity)) 
 #define IF_LOG(severity)                IF_LOG_(PLOG_DEFAULT_INSTANCE, severity)
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hi Sergius,  Thanks for sharing plog.

I am getting warnings with clang:
     warning: add explicit braces to avoid dangling else [-Wdangling-else]
     
When using:

     if(smth) LOG(info) << "hello" 

This can be avoided with:

    if(smth)
    {
          LOG(info) << "hello"
    }

But thats not practical with a big code base. 

An easy fix seems to be to return to your old form of the IF_LOG_ macro.




[  1%] Building CXX object sysrap/CMakeFiles/SysRap.dir/SMap.cc.o
/Users/blyth/opticks/sysrap/SMap.cc:26:9: warning: add explicit braces to avoid dangling else [-Wdangling-else]
        LOG(info) << ... 
        ^
/usr/local/opticks/externals/plog/include/plog/Log.h:43:41: note: expanded from macro 'LOG'
#define LOG(severity)                   LOG_(PLOG_DEFAULT_INSTANCE, severity)
                                        ^
/usr/local/opticks/externals/plog/include/plog/Log.h:42:41: note: expanded from macro 'LOG_'
#define LOG_(instance, severity)        IF_LOG_(instance, severity) (*plog::get<instance>()) += plog::Record(severity, PLOG_GET_FUNC(), __LIN...
                                        ^
/usr/local/opticks/externals/plog/include/plog/Log.h:36:124: note: expanded from macro 'IF_LOG_'
#define IF_LOG_(instance, severity)     if (!plog::get<instance>() || !plog::get<instance>()->checkSeverity(severity)) {;} else
                                                                                                                           ^
/Users/blyth/opticks/sysrap/SMap.cc:35:13: warning: add explicit braces to avoid dangling else [-Wdangling-else]
            LOG(info) 


