### PR TITLE
Make Record default move constructible

### DIFF
--- a/include/plog/Record.h
+++ b/include/plog/Record.h
@@ -108,6 +108,10 @@ namespace plog
             util::ftime(&m_time);
         }
 
+#if __cplusplus >= 201103L && defined(__cpp_rvalue_references)
+        Record(Record&&) = default;
+#endif
+
         //////////////////////////////////////////////////////////////////////////
         // Stream output operators
 


### PR DESCRIPTION
This allows move-constructing Records in C++11 and above