### PR TITLE
 make plog able to be exported from Windows dll,  Fix millisecond showing by TxtFormatter

### DIFF
--- a/include/plog/Appenders/IAppender.h
+++ b/include/plog/Appenders/IAppender.h
@@ -1,9 +1,10 @@
 #pragma once
 #include <plog/Record.h>
+#include <plog/Util.h>
 
 namespace plog
 {
-    class IAppender
+    class PLOG_DLL IAppender
     {
     public:
         virtual ~IAppender()

--- a/include/plog/Formatters/CsvFormatter.h
+++ b/include/plog/Formatters/CsvFormatter.h
@@ -20,7 +20,7 @@ namespace plog
 
             util::nostringstream ss;
             ss << t.tm_year + 1900 << PLOG_NSTR("/") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_mon + 1 << PLOG_NSTR("/") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_mday << PLOG_NSTR(";");
-            ss << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_hour << PLOG_NSTR(":") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_min << PLOG_NSTR(":") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_sec << PLOG_NSTR(".") << std::setfill(PLOG_NSTR('0')) << std::setw(3) << record.getTime().millitm << PLOG_NSTR(";");
+            ss << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_hour << PLOG_NSTR(":") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_min << PLOG_NSTR(":") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_sec << PLOG_NSTR(".") << std::setfill(PLOG_NSTR('0')) << std::setw(3) << static_cast<int> (record.getTime().millitm) << PLOG_NSTR(";");
             ss << severityToString(record.getSeverity()) << PLOG_NSTR(";");
             ss << record.getTid() << PLOG_NSTR(";");
             ss << record.getObject() << PLOG_NSTR(";");

--- a/include/plog/Formatters/TxtFormatter.h
+++ b/include/plog/Formatters/TxtFormatter.h
@@ -20,7 +20,7 @@ namespace plog
 
             util::nostringstream ss;
             ss << t.tm_year + 1900 << "-" << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_mon + 1 << PLOG_NSTR("-") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_mday << PLOG_NSTR(" ");
-            ss << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_hour << PLOG_NSTR(":") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_min << PLOG_NSTR(":") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_sec << PLOG_NSTR(".") << std::setfill(PLOG_NSTR('0')) << std::setw(3) << record.getTime().millitm << PLOG_NSTR(" ");
+            ss << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_hour << PLOG_NSTR(":") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_min << PLOG_NSTR(":") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_sec << PLOG_NSTR(".") << std::setfill(PLOG_NSTR('0')) << std::setw(3) << static_cast<int> (record.getTime().millitm) << PLOG_NSTR(" ");
             ss << std::setfill(PLOG_NSTR(' ')) << std::setw(5) << std::left << severityToString(record.getSeverity()) << PLOG_NSTR(" ");
             ss << PLOG_NSTR("[") << record.getTid() << PLOG_NSTR("] ");
             ss << PLOG_NSTR("[") << record.getFunc() << PLOG_NSTR("@") << record.getLine() << PLOG_NSTR("] ");

--- a/include/plog/Logger.h
+++ b/include/plog/Logger.h
@@ -10,7 +10,7 @@
 namespace plog
 {
     template<int instance>
-    class Logger : public util::Singleton<Logger<instance> >, public IAppender
+    class PLOG_DLL Logger : public util::Singleton<Logger<instance> >, public IAppender
     {
     public:
         Logger(Severity maxSeverity = none) : m_maxSeverity(maxSeverity)

--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -14,6 +14,18 @@
 #   endif
 #endif
 
+#if defined(_WIN32) || defined(_WIN64)
+#   if defined(PLOG_EXPORTS)
+#       define PLOG_DLL __declspec(dllexport)
+#   elif defined(PLOG_IMPORTS)
+#       define PLOG_DLL __declspec(dllimport)
+#   else
+#       define PLOG_DLL
+#   endif
+#else
+#   define PLOG_DLL 
+#endif
+
 #ifdef _WIN32
 #   include <plog/WinApi.h>
 #   include <time.h>
@@ -219,7 +231,7 @@ namespace plog
             }
         }
 
-        class NonCopyable
+        class PLOG_DLL NonCopyable
         {
         protected:
             NonCopyable()


### PR DESCRIPTION
1. By adding a definition COMMON_EXPORTS under a Visual studio project, plog can be able to use the same instance between dll & exe

2. millisecond is showing incorrectly, add cast from unsigned short to int to fix it.