### PR TITLE
Allow rollLogFiles to be called from users of RollingFileAppender

### DIFF
--- a/include/plog/Appenders/RollingFileAppender.h
+++ b/include/plog/Appenders/RollingFileAppender.h
@@ -52,7 +52,6 @@ namespace plog
             }
         }
 
-    private:
         void rollLogFiles()
         {
             m_file.close();
@@ -69,7 +68,11 @@ namespace plog
             }
 
             openLogFile();
+			
+            m_firstWrite = false;
         }
+		
+    private:
 
         void openLogFile()
         {


### PR DESCRIPTION
We had a user case where we wanted to have a clean log file on startup while keeping the previous log file. The straightforward way is to force an initial roll of the file, but the rollLogFiles is private in RollingFileAppender. 

Fortunetely, simply changing it to be public and changing the m_firstWrite flag seems to work fine.