### PR TITLE
Making sure we can build standalone under Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,12 @@ target_include_directories(plog INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 add_library(plog::plog ALIAS plog)
 
+#making sure we can build standalone under windows
+get_filename_component(CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}   ABSOLUTE)
+get_filename_component(SOURCE_DIR ${CMAKE_SOURCE_DIR} ABSOLUTE)
+
 # check if building as a stand-alone project
-if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
+if(${CURRENT_SOURCE_DIR} STREQUAL ${SOURCE_DIR})
     # add a pseudo-project to make plog headers visible in IDE
     file(GLOB_RECURSE PLOG_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h)
     add_library(plog-headers STATIC ${PLOG_HEADERS})


### PR DESCRIPTION
When accessing the cmake variables directly, the drive letter could differ in case, this way they will always match