### PR TITLE
Define macro names with "PLOG" instead of "LOG" in order to avoid con…

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ int main()
 {
     plog::init(plog::debug, "Hello.txt"); // Step2: initialize the logger.
 
-    // Step3: write log messages using a special macro. 
+    // Step3: write log messages using a special macro.
     // There are several log macros, use the macro you liked the most.
 
-    LOGD << "Hello log!"; // short macro
-    LOG_DEBUG << "Hello log!"; // long macro
-    LOG(plog::debug) << "Hello log!"; // function-style macro
+    PLOGD << "Hello log!"; // short macro
+    PLOG_DEBUG << "Hello log!"; // long macro
+    PLOG(plog::debug) << "Hello log!"; // function-style macro
 
     return 0;
 }
@@ -114,6 +114,7 @@ At first your project needs to know about plog. For that you have to:
 
 1. Add `plog/include` to the project include paths
 2. Add `#include <plog/Log.h>` into your cpp/h files (if you have precompiled headers it is a good place to add this include there)
+3. If the project include paths include `<syslog.h>` or `<sys/syslog.h>` or any other header that defines macros with names starting with "LOG", add `#define PLOG_OMIT_LOG_DEFINES` **before** `#include <plog/Log.h>`
 
 ## Step 2: Initialization
 The next step is to initialize the [Logger](#logger). This is done by the following `plog::init` function:
@@ -154,7 +155,7 @@ If one of them is zero then log rolling is disabled.
 Sample:
 
 ```cpp
-plog::init(plog::warning, "c:\\logs\\log.csv", 1000000, 5); 
+plog::init(plog::warning, "c:\\logs\\log.csv", 1000000, 5);
 ```
 
 Here the logger is initialized to write all messages with up to warning severity to a file in csv format. Maximum log file size is set to 1'000'000 bytes and 5 log files are kept.
@@ -164,37 +165,37 @@ Here the logger is initialized to write all messages with up to warning severity
 ## Step 3: Logging
 Logging is performed with the help of special macros. A log message is constructed using stream output operators `<<`. Thus it is type-safe and extendable in contrast to a format string output.
 
-### Basic logging macros 
+### Basic logging macros
 This is the most used type of logging macros. They do unconditional logging.
 
 #### Long macros:
 
 ```cpp
-LOG_VERBOSE << "verbose";
-LOG_DEBUG << "debug";
-LOG_INFO << "info";
-LOG_WARNING << "warning";
-LOG_ERROR << "error";
-LOG_FATAL << "fatal";
-LOG_NONE << "none";
+PLOG_VERBOSE << "verbose";
+PLOG_DEBUG << "debug";
+PLOG_INFO << "info";
+PLOG_WARNING << "warning";
+PLOG_ERROR << "error";
+PLOG_FATAL << "fatal";
+PLOG_NONE << "none";
 ```
 
 #### Short macros:
 
 ```cpp
-LOGV << "verbose";
-LOGD << "debug";
-LOGI << "info";
-LOGW << "warning";
-LOGE << "error";
-LOGF << "fatal";
-LOGN << "none";
+PLOGV << "verbose";
+PLOGD << "debug";
+PLOGI << "info";
+PLOGW << "warning";
+PLOGE << "error";
+PLOGF << "fatal";
+PLOGN << "none";
 ```
 
 #### Function-style macros:
 
 ```cpp
-LOG(severity) << "msg";
+PLOG(severity) << "msg";
 ```
 
 ### Conditional logging macros
@@ -203,55 +204,55 @@ These macros are used to do a conditional logging. They accept a condition as a 
 #### Long macros:
 
 ```cpp
-LOG_VERBOSE_IF(cond) << "verbose";
-LOG_DEBUG_IF(cond) << "debug";
-LOG_INFO_IF(cond) << "info";
-LOG_WARNING_IF(cond) << "warning";
-LOG_ERROR_IF(cond) << "error";
-LOG_FATAL_IF(cond) << "fatal";
-LOG_NONE_IF(cond) << "none";
+PLOG_VERBOSE_IF(cond) << "verbose";
+PLOG_DEBUG_IF(cond) << "debug";
+PLOG_INFO_IF(cond) << "info";
+PLOG_WARNING_IF(cond) << "warning";
+PLOG_ERROR_IF(cond) << "error";
+PLOG_FATAL_IF(cond) << "fatal";
+PLOG_NONE_IF(cond) << "none";
 ```
 
 #### Short macros:
 
 ```cpp
-LOGV_IF(cond) << "verbose";
-LOGD_IF(cond) << "debug";
-LOGI_IF(cond) << "info";
-LOGW_IF(cond) << "warning";
-LOGE_IF(cond) << "error";
-LOGF_IF(cond) << "fatal";
-LOGN_IF(cond) << "none";
+PLOGV_IF(cond) << "verbose";
+PLOGD_IF(cond) << "debug";
+PLOGI_IF(cond) << "info";
+PLOGW_IF(cond) << "warning";
+PLOGE_IF(cond) << "error";
+PLOGF_IF(cond) << "fatal";
+PLOGN_IF(cond) << "none";
 ```
 
 #### Function-style macros:
 
 ```cpp
-LOG_IF(severity, cond) << "msg";
+PLOG_IF(severity, cond) << "msg";
 ```
 
 ### Logger severity checker
 In some cases there is a need to perform a group of actions depending on the current logger severity level. There is a special macro for that. It helps to minimize performance penalty when the logger is inactive.
 
 ```cpp
-IF_LOG(severity)
+IF_PLOG(severity)
 ```
 
 Sample:
 
 ```cpp
-IF_LOG(plog::debug) // we want to execute the following statements only at debug severity (and higher)
+IF_PLOG(plog::debug) // we want to execute the following statements only at debug severity (and higher)
 {
     for (int i = 0; i < vec.size(); ++i)
     {
-        LOGD << "vec[" << i << "]: " << vec[i];
+        PLOGD << "vec[" << i << "]: " << vec[i];
     }
 }
 ```
 
 # Advanced usage
 
-## Changing severity at runtime 
+## Changing severity at runtime
 It is possible to set the maximum severity not only at the logger initialization time but at any time later. There are special accessor methods:
 
 ```cpp
@@ -278,7 +279,7 @@ Non-typical log cases require the use of custom initialization. It is done by th
 Logger& init(Severity maxSeverity = none, IAppender* appender = NULL);
 ```
 
-You have to construct an [Appender](#appender) parameterized with a [Formatter](#formatter) and pass it to the `plog::init` function. 
+You have to construct an [Appender](#appender) parameterized with a [Formatter](#formatter) and pass it to the `plog::init` function.
 
 *Note: a lifetime of the appender should be static!*
 
@@ -324,9 +325,9 @@ Logger<instance>* get<instance>();
 All logging macros have their special versions that accept an instance parameter. These kind of macros have an underscore at the end:
 
 ```cpp
-LOGD_(instance) << "debug";
-LOGD_IF_(instance, condition) << "conditional debug";
-IF_LOG_(instance, severity)
+PLOGD_(instance) << "debug";
+PLOGD_IF_(instance, condition) << "conditional debug";
+IF_PLOG_(instance, severity)
 ```
 
 Sample:
@@ -343,10 +344,10 @@ int main()
     plog::init<SecondLog>(plog::debug, "MultiInstance-second.txt"); // Initialize the 2nd logger instance.
 
     // Write some messages to the default log.
-    LOGD << "Hello default log!";
+    PLOGD << "Hello default log!";
 
     // Write some messages to the 2nd log.
-    LOGD_(SecondLog) << "Hello second log!";
+    PLOGD_(SecondLog) << "Hello second log!";
 
     return 0;
 }
@@ -362,7 +363,7 @@ Sample:
 ```cpp
 // shared library
 
-// Function that initializes the logger in the shared library. 
+// Function that initializes the logger in the shared library.
 extern "C" void EXPORT initialize(plog::Severity severity, plog::IAppender* appender)
 {
     plog::init(severity, appender); // Initialize the shared library logger.
@@ -371,7 +372,7 @@ extern "C" void EXPORT initialize(plog::Severity severity, plog::IAppender* appe
 // Function that produces a log message.
 extern "C" void EXPORT foo()
 {
-    LOGI << "Hello from shared lib!";
+    PLOGI << "Hello from shared lib!";
 }
 ```
 
@@ -386,7 +387,7 @@ int main()
 {
     plog::init(plog::debug, "ChainedApp.txt"); // Initialize the main logger.
 
-    LOGD << "Hello from app!"; // Write a log message.
+    PLOGD << "Hello from app!"; // Write a log message.
 
     initialize(plog::debug, plog::get()); // Initialize the logger in the shared library. Note that it has its own severity.
     foo(); // Call a function from the shared library that produces a log message.
@@ -403,7 +404,7 @@ int main()
 Plog is designed to be small but flexible, so it prefers templates to interface inheritance. All main entities are shown on the following UML diagram:
 
 ![Plog class diagram](http://gravizo.com/svg?@startuml;class%20Logger<int%20instance>%20<<singleton>>%20{;%20%20%20%20+addAppender%28%29;%20%20%20%20+getMaxSeverity%28%29;%20%20%20%20+setMaxSeverity%28%29;%20%20%20%20+checkSeverity%28%29;%20%20%20%20-maxSeverity;%20%20%20%20-appenders;};package%20Appenders%20<<Frame>>%20{;%20%20%20%20interface%20IAppender%20{;%20%20%20%20%20%20%20%20+write%28%29;%20%20%20%20};%20%20%20%20;%20%20%20%20class%20RollingFileAppender<Formatter,%20Converter>;%20%20%20%20class%20ConsoleAppender<Formatter>;%20%20%20%20class%20ColorConsoleAppender<Formatter>;%20%20%20%20class%20AndroidAppender<Formatter>;%20%20%20%20class%20EventLogAppender<Formatter>;%20%20%20%20class%20DebugOutputAppender<Formatter>;%20%20%20%20ConsoleAppender%20<|--%20ColorConsoleAppender;%20%20%20%20IAppender%20<|-u-%20Logger;%20%20%20%20IAppender%20<|--%20RollingFileAppender;%20%20%20%20IAppender%20<|--%20ConsoleAppender;%20%20%20%20IAppender%20<|--%20AndroidAppender;%20%20%20%20IAppender%20<|--%20EventLogAppender;%20%20%20%20IAppender%20<|--%20DebugOutputAppender;%20%20%20%20;%20%20%20%20Logger%20"1"%20o--%20"0..n"%20IAppender;};package%20Formatters%20<<Frame>>%20{;%20%20%20%20class%20CsvFormatter%20{;%20%20%20%20%20%20%20%20{static}%20header%28%29;%20%20%20%20%20%20%20%20{static}%20format%28%29;%20%20%20%20};%20%20%20%20class%20TxtFormatter%20{;%20%20%20%20%20%20%20%20{static}%20header%28%29;%20%20%20%20%20%20%20%20{static}%20format%28%29;%20%20%20%20};%20%20%20%20class%20FuncMessageFormatter%20{;%20%20%20%20%20%20%20%20{static}%20header%28%29;%20%20%20%20%20%20%20%20{static}%20format%28%29;%20%20%20%20};%20%20%20%20class%20MessageOnlyFormatter%20{;%20%20%20%20%20%20%20%20{static}%20header%28%29;%20%20%20%20%20%20%20%20{static}%20format%28%29;%20%20%20%20};};package%20Converters%20<<Frame>>%20{;%20%20%20%20class%20UTF8Converter%20{;%20%20%20%20%20%20%20%20{static}%20header%28%29;%20%20%20%20%20%20%20%20{static}%20convert%28%29;%20%20%20%20};%20%20%20%20class%20NativeEOLConverter%20<NextConverter>{;%20%20%20%20%20%20%20%20{static}%20header%28%29;%20%20%20%20%20%20%20%20{static}%20convert%28%29;%20%20%20%20};};enum%20Severity%20{;%20%20%20%20none,;%20%20%20%20fatal,;%20%20%20%20error,;%20%20%20%20warning,;%20%20%20%20info,;%20%20%20%20debug,;%20%20%20%20verbose;};class%20Record%20{;%20%20%20%20+operator<<%28%29;%20%20%20%20-time;%20%20%20%20-severity;%20%20%20%20-tid;%20%20%20%20-object;%20%20%20%20-line;%20%20%20%20-file;%20%20%20%20-message;%20%20%20%20-func;};hide%20empty%20members;hide%20empty%20fields;@enduml)
-<!-- 
+<!--
 @startuml
 
 class Logger<int instance> <<singleton>> {
@@ -419,7 +420,7 @@ package Appenders <<Frame>> {
     interface IAppender {
         +write();
     }
-    
+
     class RollingFileAppender<Formatter, Converter>
     class ConsoleAppender<Formatter>
     class ColorConsoleAppender<Formatter>
@@ -434,7 +435,7 @@ package Appenders <<Frame>> {
     IAppender <|-- AndroidAppender
     IAppender <|-- EventLogAppender
     IAppender <|-- DebugOutputAppender
-    
+
     Logger "1" o-- "0..n" IAppender
 }
 
@@ -509,10 +510,10 @@ There are 5 functional parts:
 
 The log data flow is shown below:
 
-![Log data flow](http://gravizo.com/g?@startuml;%28*%29%20-r->%20"LOG%20macro";-r->%20"Record";-r->%20"Logger";-r-->%20"Appender";-d->%20"Formatter";-d->%20"Converter";-u->%20"Appender";-r->%20%28*%29;@enduml)
+![Log data flow](http://gravizo.com/g?@startuml;%28*%29%20-r->%20"PLOG%20macro";-r->%20"Record";-r->%20"Logger";-r-->%20"Appender";-d->%20"Formatter";-d->%20"Converter";-u->%20"Appender";-r->%20%28*%29;@enduml)
 <!--
 @startuml
-(*) -r-> "LOG macro"
+(*) -r-> "PLOG macro"
 -r-> "Record"
 -r-> "Logger"
 -r-> "Appender"
@@ -532,13 +533,13 @@ class Logger : public util::Singleton<Logger<instance> >, public IAppender
 {
 public:
     Logger(Severity maxSeverity = none);
-    
+
     Logger& addAppender(IAppender* appender);
-    
+
     Severity getMaxSeverity() const;
     void setMaxSeverity(Severity severity);
     bool checkSeverity(Severity severity) const;
-    
+
     virtual void write(const Record& record);
     void operator+=(const Record& record);
 };
@@ -565,19 +566,19 @@ class Record
 {
 public:
     Record(Severity severity, const char* func, size_t line, const char* file, const void* object);
-    
+
     //////////////////////////////////////////////////////////////////////////
     // Stream output operators
-        
+
     Record& operator<<(char data);
     Record& operator<<(wchar_t data);
-    
+
     template<typename T>
     Record& operator<<(const T& data);
-    
+
     //////////////////////////////////////////////////////////////////////////
     // Getters
-    
+
     virtual const util::Time& getTime() const;
     virtual Severity getSeverity() const;
     virtual unsigned int getTid() const;
@@ -617,8 +618,8 @@ This is a classic log format available in almost any log library. It is good for
 2014-11-11 00:29:06.261 WARN  [4460] [main@25] warning
 2014-11-11 00:29:06.261 DEBUG [4460] [main@26] debug
 2014-11-11 00:29:06.261 INFO  [4460] [main@32] This is a message with "quotes"!
-2014-11-11 00:29:06.261 DEBUG [4460] [Object::Object@8] 
-2014-11-11 00:29:06.261 DEBUG [4460] [Object::~Object@13] 
+2014-11-11 00:29:06.261 DEBUG [4460] [Object::Object@8]
+2014-11-11 00:29:06.261 DEBUG [4460] [Object::~Object@13]
 ```
 
 ### CsvFormatter
@@ -648,12 +649,12 @@ main@24: info
 main@25: warning
 main@26: debug
 main@32: This is a message with "quotes"!
-Object::Object@8: 
-Object::~Object@13: 
+Object::Object@8:
+Object::~Object@13:
 ```
 
 ### MessageOnlyFormatter
-Use this formatter when you're interested only in a log message. 
+Use this formatter when you're interested only in a log message.
 
 ```
 fatal
@@ -665,7 +666,7 @@ This is a message with "quotes"!
 ```
 
 ## Converter
-[Converter](#converter) is responsible for conversion of [Formatter](#formatter) output data to a raw buffer (represented as `std::string`). It is used by [RollingFileAppender](#rollingfileappender) to perform a conversion before writing to a file. There is no base class for converters, they are implemented as classes with static functions `convert` and `header`: 
+[Converter](#converter) is responsible for conversion of [Formatter](#formatter) output data to a raw buffer (represented as `std::string`). It is used by [RollingFileAppender](#rollingfileappender) to perform a conversion before writing to a file. There is no base class for converters, they are implemented as classes with static functions `convert` and `header`:
 
 ```cpp
 class Converter
@@ -679,7 +680,7 @@ public:
 *See [How to implement a custom converter](#custom-converter).*
 
 ### UTF8Converter
-[UTF8Converter](#utf8converter) is a default converter in plog. It converts string data to UTF-8 with BOM. 
+[UTF8Converter](#utf8converter) is a default converter in plog. It converts string data to UTF-8 with BOM.
 
 ### NativeEOLConverter
 This converter converts `<LF>` line endings to `<CRLF>` on Windows and do nothing on everything else. As a template parameter it accepts another converter that is called next (by default [UTF8Converter](#utf8converter)).
@@ -717,7 +718,7 @@ RollingFileAppender<Formatter, Converter>::RollingFileAppender(const util::nchar
 - `maxFileSize` - the maximum log file size in bytes
 - `maxFiles` - a number of log files to keep
 
-If `maxFileSize` or `maxFiles` is 0 then rolling behaviour is turned off. 
+If `maxFileSize` or `maxFiles` is 0 then rolling behaviour is turned off.
 
 The sample file names produced by this appender:
 
@@ -780,7 +781,7 @@ DebugOutputAppender<Formatter>::DebugOutputAppender();
 Log messages are constructed using lazy stream evaluation. It means that if a log message will be dropped (because of its severity) then stream output operators are not executed. Thus performance penalty of unprinted log messages is negligible.
 
 ```cpp
-LOGD << /* the following statements will be executed only when the logger severity is debug or higher */ ...
+PLOGD << /* the following statements will be executed only when the logger severity is debug or higher */ ...
 ```
 
 ## Stream improvements over std::ostream
@@ -854,7 +855,7 @@ Whether `wchar_t`, `wchar_t*`, `std::wstring` can be streamed to log messages or
 *Note: wide string support requires linking to `iconv` on macOS.*
 
 ## Performance
-Plog is not using any asynchronous techniques so it may slow down your application on large volumes of log messages. 
+Plog is not using any asynchronous techniques so it may slow down your application on large volumes of log messages.
 
 Producing a single log message takes the following amount of time:
 
@@ -874,8 +875,8 @@ Assume 20 microsec per a log call then 500 log calls per a second will slow down
 With the help of [fmtlib](https://github.com/fmtlib/fmt) printf style formatting can be used in plog:
 
 ```cpp
-LOGI << fmt::sprintf("%d %s", 10, "test");
-LOGI << fmt::format("{0} {1}", 12, "test");
+PLOGI << fmt::sprintf("%d %s", 10, "test");
+PLOGI << fmt::format("{0} {1}", 12, "test");
 ```
 
 # Extending
@@ -1012,6 +1013,7 @@ Plog is licensed under the [MPL version 2.0](http://mozilla.org/MPL/2.0/). You c
 # Version history
 
 ## Version 1.1.5 (TBD)
+- Fix #25: Add macro names PLOG* to avoid name conflicts with syslog.h or sys/syslog.h, allow control of including olf LOG* macro names for downward compatibility
 
 ## Version 1.1.4 (26 Mar 2018)
 - New: Add `-Wundef` support
@@ -1024,7 +1026,7 @@ Plog is licensed under the [MPL version 2.0](http://mozilla.org/MPL/2.0/). You c
 - Fix: Fix compiling with cmake 2.8
 
 ## Version 1.1.3 (09 Aug 2017)
-- New: Introduce `PLOG_ENABLE_WCHAR_INPUT` macro to control wide string support
+- New: Introduce `LOG_ENABLE_WCHAR_INPUT` macro to control wide string support
 - New #63: Add support for managed C++ `System::String^`
 - New #61: Add missing macros for logging with severity NONE
 - Fix #59: Unable to build [NativeEOLConverter](#nativeeolconverter)/[UTF8Converter](#utf8converter) using Visual Studio
@@ -1048,7 +1050,7 @@ Plog is licensed under the [MPL version 2.0](http://mozilla.org/MPL/2.0/). You c
 - Fix #34: Introduce binary compatible interface to Record (WARNING: this is not compatible with 1.0.x version in [Chained mode](#chained-loggers), so don't mix 1.1.x and 1.0.x)
 
 ## Version 1.0.2 (19 Nov 2016)
-- New #11: Default instance can be set via `PLOG_DEFAULT_INSTANCE`
+- New #11: Default instance can be set via `LOG_DEFAULT_INSTANCE`
 - New #30: Support for `QString`
 - New: Support for C++Builder
 - New #15: `severityFromString` function

--- a/include/plog/Log.h
+++ b/include/plog/Log.h
@@ -33,81 +33,167 @@
 //////////////////////////////////////////////////////////////////////////
 // Log severity level checker
 
-#define IF_LOG_(instance, severity)     if (!plog::get<instance>() || !plog::get<instance>()->checkSeverity(severity)) {;} else
-#define IF_LOG(severity)                IF_LOG_(PLOG_DEFAULT_INSTANCE, severity)
+#define IF_PLOG_(instance, severity)     if (!plog::get<instance>() || !plog::get<instance>()->checkSeverity(severity)) {;} else
+#define IF_PLOG(severity)                IF_PLOG_(PLOG_DEFAULT_INSTANCE, severity)
 
 //////////////////////////////////////////////////////////////////////////
 // Main logging macros
 
-#define LOG_(instance, severity)        IF_LOG_(instance, severity) (*plog::get<instance>()) += plog::Record(severity, PLOG_GET_FUNC(), __LINE__, PLOG_GET_FILE(), PLOG_GET_THIS()).ref()
-#define LOG(severity)                   LOG_(PLOG_DEFAULT_INSTANCE, severity)
+#define PLOG_(instance, severity)        IF_PLOG_(instance, severity) (*plog::get<instance>()) += plog::Record(severity, PLOG_GET_FUNC(), __LINE__, PLOG_GET_FILE(), PLOG_GET_THIS()).ref()
+#define PLOG(severity)                   PLOG_(PLOG_DEFAULT_INSTANCE, severity)
 
-#define LOG_VERBOSE                     LOG(plog::verbose)
-#define LOG_DEBUG                       LOG(plog::debug)
-#define LOG_INFO                        LOG(plog::info)
-#define LOG_WARNING                     LOG(plog::warning)
-#define LOG_ERROR                       LOG(plog::error)
-#define LOG_FATAL                       LOG(plog::fatal)
-#define LOG_NONE                        LOG(plog::none)
+#define PLOG_VERBOSE                     PLOG(plog::verbose)
+#define PLOG_DEBUG                       PLOG(plog::debug)
+#define PLOG_INFO                        PLOG(plog::info)
+#define PLOG_WARNING                     PLOG(plog::warning)
+#define PLOG_ERROR                       PLOG(plog::error)
+#define PLOG_FATAL                       PLOG(plog::fatal)
+#define PLOG_NONE                        PLOG(plog::none)
 
-#define LOG_VERBOSE_(instance)          LOG_(instance, plog::verbose)
-#define LOG_DEBUG_(instance)            LOG_(instance, plog::debug)
-#define LOG_INFO_(instance)             LOG_(instance, plog::info)
-#define LOG_WARNING_(instance)          LOG_(instance, plog::warning)
-#define LOG_ERROR_(instance)            LOG_(instance, plog::error)
-#define LOG_FATAL_(instance)            LOG_(instance, plog::fatal)
-#define LOG_NONE_(instance)             LOG_(instance, plog::none)
+#define PLOG_VERBOSE_(instance)          PLOG_(instance, plog::verbose)
+#define PLOG_DEBUG_(instance)            PLOG_(instance, plog::debug)
+#define PLOG_INFO_(instance)             PLOG_(instance, plog::info)
+#define PLOG_WARNING_(instance)          PLOG_(instance, plog::warning)
+#define PLOG_ERROR_(instance)            PLOG_(instance, plog::error)
+#define PLOG_FATAL_(instance)            PLOG_(instance, plog::fatal)
+#define PLOG_NONE_(instance)             PLOG_(instance, plog::none)
 
-#define LOGV                            LOG_VERBOSE
-#define LOGD                            LOG_DEBUG
-#define LOGI                            LOG_INFO
-#define LOGW                            LOG_WARNING
-#define LOGE                            LOG_ERROR
-#define LOGF                            LOG_FATAL
-#define LOGN                            LOG_NONE
+#define PLOGV                            PLOG_VERBOSE
+#define PLOGD                            PLOG_DEBUG
+#define PLOGI                            PLOG_INFO
+#define PLOGW                            PLOG_WARNING
+#define PLOGE                            PLOG_ERROR
+#define PLOGF                            PLOG_FATAL
+#define PLOGN                            PLOG_NONE
 
-#define LOGV_(instance)                 LOG_VERBOSE_(instance)
-#define LOGD_(instance)                 LOG_DEBUG_(instance)
-#define LOGI_(instance)                 LOG_INFO_(instance)
-#define LOGW_(instance)                 LOG_WARNING_(instance)
-#define LOGE_(instance)                 LOG_ERROR_(instance)
-#define LOGF_(instance)                 LOG_FATAL_(instance)
-#define LOGN_(instance)                 LOG_NONE_(instance)
+#define PLOGV_(instance)                 PLOG_VERBOSE_(instance)
+#define PLOGD_(instance)                 PLOG_DEBUG_(instance)
+#define PLOGI_(instance)                 PLOG_INFO_(instance)
+#define PLOGW_(instance)                 PLOG_WARNING_(instance)
+#define PLOGE_(instance)                 PLOG_ERROR_(instance)
+#define PLOGF_(instance)                 PLOG_FATAL_(instance)
+#define PLOGN_(instance)                 PLOG_NONE_(instance)
 
 //////////////////////////////////////////////////////////////////////////
 // Conditional logging macros
 
-#define LOG_IF_(instance, severity, condition)  if (!(condition)) {;} else LOG_(instance, severity)
-#define LOG_IF(severity, condition)             LOG_IF_(PLOG_DEFAULT_INSTANCE, severity, condition)
+#define PLOG_IF_(instance, severity, condition)  if (!(condition)) {;} else PLOG_(instance, severity)
+#define PLOG_IF(severity, condition)             PLOG_IF_(PLOG_DEFAULT_INSTANCE, severity, condition)
 
-#define LOG_VERBOSE_IF(condition)               LOG_IF(plog::verbose, condition)
-#define LOG_DEBUG_IF(condition)                 LOG_IF(plog::debug, condition)
-#define LOG_INFO_IF(condition)                  LOG_IF(plog::info, condition)
-#define LOG_WARNING_IF(condition)               LOG_IF(plog::warning, condition)
-#define LOG_ERROR_IF(condition)                 LOG_IF(plog::error, condition)
-#define LOG_FATAL_IF(condition)                 LOG_IF(plog::fatal, condition)
-#define LOG_NONE_IF(condition)                  LOG_IF(plog::none, condition)
+#define PLOG_VERBOSE_IF(condition)               PLOG_IF(plog::verbose, condition)
+#define PLOG_DEBUG_IF(condition)                 PLOG_IF(plog::debug, condition)
+#define PLOG_INFO_IF(condition)                  PLOG_IF(plog::info, condition)
+#define PLOG_WARNING_IF(condition)               PLOG_IF(plog::warning, condition)
+#define PLOG_ERROR_IF(condition)                 PLOG_IF(plog::error, condition)
+#define PLOG_FATAL_IF(condition)                 PLOG_IF(plog::fatal, condition)
+#define PLOG_NONE_IF(condition)                  PLOG_IF(plog::none, condition)
 
-#define LOG_VERBOSE_IF_(instance, condition)    LOG_IF_(instance, plog::verbose, condition)
-#define LOG_DEBUG_IF_(instance, condition)      LOG_IF_(instance, plog::debug, condition)
-#define LOG_INFO_IF_(instance, condition)       LOG_IF_(instance, plog::info, condition)
-#define LOG_WARNING_IF_(instance, condition)    LOG_IF_(instance, plog::warning, condition)
-#define LOG_ERROR_IF_(instance, condition)      LOG_IF_(instance, plog::error, condition)
-#define LOG_FATAL_IF_(instance, condition)      LOG_IF_(instance, plog::fatal, condition)
-#define LOG_NONE_IF_(instance, condition)       LOG_IF_(instance, plog::none, condition)
+#define PLOG_VERBOSE_IF_(instance, condition)    PLOG_IF_(instance, plog::verbose, condition)
+#define PLOG_DEBUG_IF_(instance, condition)      PLOG_IF_(instance, plog::debug, condition)
+#define PLOG_INFO_IF_(instance, condition)       PLOG_IF_(instance, plog::info, condition)
+#define PLOG_WARNING_IF_(instance, condition)    PLOG_IF_(instance, plog::warning, condition)
+#define PLOG_ERROR_IF_(instance, condition)      PLOG_IF_(instance, plog::error, condition)
+#define PLOG_FATAL_IF_(instance, condition)      PLOG_IF_(instance, plog::fatal, condition)
+#define PLOG_NONE_IF_(instance, condition)       PLOG_IF_(instance, plog::none, condition)
 
-#define LOGV_IF(condition)                      LOG_VERBOSE_IF(condition)
-#define LOGD_IF(condition)                      LOG_DEBUG_IF(condition)
-#define LOGI_IF(condition)                      LOG_INFO_IF(condition)
-#define LOGW_IF(condition)                      LOG_WARNING_IF(condition)
-#define LOGE_IF(condition)                      LOG_ERROR_IF(condition)
-#define LOGF_IF(condition)                      LOG_FATAL_IF(condition)
-#define LOGN_IF(condition)                      LOG_NONE_IF(condition)
+#define PLOGV_IF(condition)                      PLOG_VERBOSE_IF(condition)
+#define PLOGD_IF(condition)                      PLOG_DEBUG_IF(condition)
+#define PLOGI_IF(condition)                      PLOG_INFO_IF(condition)
+#define PLOGW_IF(condition)                      PLOG_WARNING_IF(condition)
+#define PLOGE_IF(condition)                      PLOG_ERROR_IF(condition)
+#define PLOGF_IF(condition)                      PLOG_FATAL_IF(condition)
+#define PLOGN_IF(condition)                      PLOG_NONE_IF(condition)
 
-#define LOGV_IF_(instance, condition)           LOG_VERBOSE_IF_(instance, condition)
-#define LOGD_IF_(instance, condition)           LOG_DEBUG_IF_(instance, condition)
-#define LOGI_IF_(instance, condition)           LOG_INFO_IF_(instance, condition)
-#define LOGW_IF_(instance, condition)           LOG_WARNING_IF_(instance, condition)
-#define LOGE_IF_(instance, condition)           LOG_ERROR_IF_(instance, condition)
-#define LOGF_IF_(instance, condition)           LOG_FATAL_IF_(instance, condition)
-#define LOGN_IF_(instance, condition)           LOG_NONE_IF_(instance, condition)
+#define PLOGV_IF_(instance, condition)           PLOG_VERBOSE_IF_(instance, condition)
+#define PLOGD_IF_(instance, condition)           PLOG_DEBUG_IF_(instance, condition)
+#define PLOGI_IF_(instance, condition)           PLOG_INFO_IF_(instance, condition)
+#define PLOGW_IF_(instance, condition)           PLOG_WARNING_IF_(instance, condition)
+#define PLOGE_IF_(instance, condition)           PLOG_ERROR_IF_(instance, condition)
+#define PLOGF_IF_(instance, condition)           PLOG_FATAL_IF_(instance, condition)
+#define PLOGN_IF_(instance, condition)           PLOG_NONE_IF_(instance, condition)
+
+// Old macro names for downward compatibility. To bypass including these macro names, add
+// #define PLOG_OMIT_LOG_DEFINES before #include <plog/Log.h>
+#ifndef PLOG_OMIT_LOG_DEFINES
+//////////////////////////////////////////////////////////////////////////
+// Log severity level checker
+
+#define IF_LOG_(instance, severity)     if (!plog::get<instance>() || !plog::get<instance>()->checkSeverity(severity)) {;} else
+#define IF_LOG(severity)                IF_PLOG_(PLOG_DEFAULT_INSTANCE, severity)
+
+//////////////////////////////////////////////////////////////////////////
+// Main logging macros - can be changed later to point at macros for a different logging package
+
+#define LOG_(instance, severity)        IF_PLOG_(instance, severity) (*plog::get<instance>()) += plog::Record(severity, PLOG_GET_FUNC(), __LINE__, PLOG_GET_FILE(), PLOG_GET_THIS()).ref()
+#define LOG(severity)                   PLOG_(PLOG_DEFAULT_INSTANCE, severity)
+
+#define LOG_VERBOSE                     PLOG(plog::verbose)
+#define LOG_DEBUG                       PLOG(plog::debug)
+#define LOG_INFO                        PLOG(plog::info)
+#define LOG_WARNING                     PLOG(plog::warning)
+#define LOG_ERROR                       PLOG(plog::error)
+#define LOG_FATAL                       PLOG(plog::fatal)
+#define LOG_NONE                        PLOG(plog::none)
+
+#define LOG_VERBOSE_(instance)          PLOG_(instance, plog::verbose)
+#define LOG_DEBUG_(instance)            PLOG_(instance, plog::debug)
+#define LOG_INFO_(instance)             PLOG_(instance, plog::info)
+#define LOG_WARNING_(instance)          PLOG_(instance, plog::warning)
+#define LOG_ERROR_(instance)            PLOG_(instance, plog::error)
+#define LOG_FATAL_(instance)            PLOG_(instance, plog::fatal)
+#define LOG_NONE_(instance)             PLOG_(instance, plog::none)
+
+#define LOGV                            PLOG_VERBOSE
+#define LOGD                            PLOG_DEBUG
+#define LOGI                            PLOG_INFO
+#define LOGW                            PLOG_WARNING
+#define LOGE                            PLOG_ERROR
+#define LOGF                            PLOG_FATAL
+#define LOGN                            PLOG_NONE
+
+#define LOGV_(instance)                 PLOG_VERBOSE_(instance)
+#define LOGD_(instance)                 PLOG_DEBUG_(instance)
+#define LOGI_(instance)                 PLOG_INFO_(instance)
+#define LOGW_(instance)                 PLOG_WARNING_(instance)
+#define LOGE_(instance)                 PLOG_ERROR_(instance)
+#define LOGF_(instance)                 PLOG_FATAL_(instance)
+#define LOGN_(instance)                 PLOG_NONE_(instance)
+
+//////////////////////////////////////////////////////////////////////////
+// Conditional logging macros
+
+#define LOG_IF_(instance, severity, condition)  if (!(condition)) {;} else PLOG_(instance, severity)
+#define LOG_IF(severity, condition)             PLOG_IF_(PLOG_DEFAULT_INSTANCE, severity, condition)
+
+#define LOG_VERBOSE_IF(condition)               PLOG_IF(plog::verbose, condition)
+#define LOG_DEBUG_IF(condition)                 PLOG_IF(plog::debug, condition)
+#define LOG_INFO_IF(condition)                  PLOG_IF(plog::info, condition)
+#define LOG_WARNING_IF(condition)               PLOG_IF(plog::warning, condition)
+#define LOG_ERROR_IF(condition)                 PLOG_IF(plog::error, condition)
+#define LOG_FATAL_IF(condition)                 PLOG_IF(plog::fatal, condition)
+#define LOG_NONE_IF(condition)                  PLOG_IF(plog::none, condition)
+
+#define LOG_VERBOSE_IF_(instance, condition)    PLOG_IF_(instance, plog::verbose, condition)
+#define LOG_DEBUG_IF_(instance, condition)      PLOG_IF_(instance, plog::debug, condition)
+#define LOG_INFO_IF_(instance, condition)       PLOG_IF_(instance, plog::info, condition)
+#define LOG_WARNING_IF_(instance, condition)    PLOG_IF_(instance, plog::warning, condition)
+#define LOG_ERROR_IF_(instance, condition)      PLOG_IF_(instance, plog::error, condition)
+#define LOG_FATAL_IF_(instance, condition)      PLOG_IF_(instance, plog::fatal, condition)
+#define LOG_NONE_IF_(instance, condition)       PLOG_IF_(instance, plog::none, condition)
+
+#define LOGV_IF(condition)                      PLOG_VERBOSE_IF(condition)
+#define LOGD_IF(condition)                      PLOG_DEBUG_IF(condition)
+#define LOGI_IF(condition)                      PLOG_INFO_IF(condition)
+#define LOGW_IF(condition)                      PLOG_WARNING_IF(condition)
+#define LOGE_IF(condition)                      PLOG_ERROR_IF(condition)
+#define LOGF_IF(condition)                      PLOG_FATAL_IF(condition)
+#define LOGN_IF(condition)                      PLOG_NONE_IF(condition)
+
+#define LOGV_IF_(instance, condition)           PLOG_VERBOSE_IF_(instance, condition)
+#define LOGD_IF_(instance, condition)           PLOG_DEBUG_IF_(instance, condition)
+#define LOGI_IF_(instance, condition)           PLOG_INFO_IF_(instance, condition)
+#define LOGW_IF_(instance, condition)           PLOG_WARNING_IF_(instance, condition)
+#define LOGE_IF_(instance, condition)           PLOG_ERROR_IF_(instance, condition)
+#define LOGF_IF_(instance, condition)           PLOG_FATAL_IF_(instance, condition)
+#define LOGN_IF_(instance, condition)           PLOG_NONE_IF_(instance, condition)
+#endif

--- a/samples/Android/jni/Sample.cpp
+++ b/samples/Android/jni/Sample.cpp
@@ -13,5 +13,5 @@ extern "C" void Java_com_github_sergius_myapp_Sample_foo(JNIEnv* env, jobject ob
     static plog::AndroidAppender<plog::FuncMessageFormatter> appender("MyApp"); // Create an appender and set a log tag.
     static plog::Logger<0>& logger = plog::init(plog::debug, &appender); // Initialize the logger with the appender.
 
-    LOGD << "Hello Android!";
+    PLOGD << "Hello Android!";
 }

--- a/samples/Chained/ChainedApp/Main.cpp
+++ b/samples/Chained/ChainedApp/Main.cpp
@@ -12,7 +12,7 @@ int main()
 {
     plog::init(plog::debug, "ChainedApp.txt"); // Initialize the main logger.
 
-    LOGD << "Hello from app!"; // Write a log message.
+    PLOGD << "Hello from app!"; // Write a log message.
 
     initialize(plog::debug, plog::get()); // Initialize the logger in the shared library. Note that it has its own severity.
     foo(); // Call a function from the shared library that produces a log message.

--- a/samples/Chained/ChainedLib/Main.cpp
+++ b/samples/Chained/ChainedLib/Main.cpp
@@ -20,5 +20,5 @@ extern "C" void EXPORT initialize(plog::Severity severity, plog::IAppender* appe
 // Function that produces a log message.
 extern "C" void EXPORT foo()
 {
-    LOGI << "Hello from shared lib!";
+    PLOGI << "Hello from shared lib!";
 }

--- a/samples/ColorConsole/Main.cpp
+++ b/samples/ColorConsole/Main.cpp
@@ -11,12 +11,12 @@ int main()
     plog::init(plog::verbose, &consoleAppender);
 
     // Log severity levels are printed in different colors.
-    LOG_VERBOSE << "This is a VERBOSE message";
-    LOG_DEBUG << "This is a DEBUG message";
-    LOG_INFO << "This is an INFO message";
-    LOG_WARNING << "This is a WARNING message";
-    LOG_ERROR << "This is an ERROR message";
-    LOG_FATAL << "This is a FATAL message";
+    PLOG_VERBOSE << "This is a VERBOSE message";
+    PLOG_DEBUG << "This is a DEBUG message";
+    PLOG_INFO << "This is an INFO message";
+    PLOG_WARNING << "This is a WARNING message";
+    PLOG_ERROR << "This is an ERROR message";
+    PLOG_FATAL << "This is a FATAL message";
 
     return 0;
 }

--- a/samples/CustomAppender/Main.cpp
+++ b/samples/CustomAppender/Main.cpp
@@ -34,7 +34,7 @@ int main()
     static plog::MyAppender<plog::FuncMessageFormatter> myAppender; // Create our custom appender. 
     plog::init(plog::debug, &myAppender); // Initialize the logger with our appender.
 
-    LOGD << "A debug message!";
+    PLOGD << "A debug message!";
 
     myAppender.getMessageList(); // This returns a list of stored log messages. 
 

--- a/samples/CustomConverter/Main.cpp
+++ b/samples/CustomConverter/Main.cpp
@@ -40,8 +40,8 @@ int main()
     static plog::RollingFileAppender<plog::TxtFormatter, plog::MyConverter> appender("CustomConverter.txt"); // Create an appender and pass our converter as a template parameter.
     plog::init(plog::debug, &appender); // Initialize the logger with the appender.
 
-    LOGD << "A debug message!";
-    LOGD << "Another one debug message!";
+    PLOGD << "A debug message!";
+    PLOGD << "Another one debug message!";
 
     return 0;
 }

--- a/samples/CustomFormatter/Main.cpp
+++ b/samples/CustomFormatter/Main.cpp
@@ -28,7 +28,7 @@ int main()
 {
     plog::init<plog::MyFormatter>(plog::debug, "CustomFormatter.txt"); // Initialize the logger and pass our formatter as a template parameter to init function.
 
-    LOGD << "A debug message!";
+    PLOGD << "A debug message!";
 
     return 0;
 }

--- a/samples/CustomType/Main.cpp
+++ b/samples/CustomType/Main.cpp
@@ -25,8 +25,8 @@ int main()
     Point pt1 = { 0, 0 };
     Point pt2 = { 10, -5 };
 
-    LOGI << "We've got a line with coords: " << pt1 << pt2; // Print our type to the log stream.
-    LOGI << pt1 << pt2 << " - test for a custom type at begin of the stream"; // Print our type to the log stream.
+    PLOGI << "We've got a line with coords: " << pt1 << pt2; // Print our type to the log stream.
+    PLOGI << pt1 << pt2 << " - test for a custom type at begin of the stream"; // Print our type to the log stream.
 
     return 0;
 }

--- a/samples/DebugOutput/Main.cpp
+++ b/samples/DebugOutput/Main.cpp
@@ -10,9 +10,9 @@ int main()
     static plog::DebugOutputAppender<plog::TxtFormatter> debugOutputAppender;
     plog::init(plog::verbose, &debugOutputAppender);
 
-    LOGD << "Hello log!"; // short macro
-    LOG_DEBUG << "Hello log!"; // long macro
-    LOG(plog::debug) << "Hello log!"; // function-style macro
+    PLOGD << "Hello log!"; // short macro
+    PLOG_DEBUG << "Hello log!"; // long macro
+    PLOG(plog::debug) << "Hello log!"; // function-style macro
 
     return 0;
 }

--- a/samples/Demo/Main.cpp
+++ b/samples/Demo/Main.cpp
@@ -11,79 +11,79 @@ int main()
     plog::init(plog::debug, "Demo.csv", 5000, 3); // Initialize the logger.
 
     // Log macro types.
-    LOGD << "Hello log!"; // short macro
-    LOG_DEBUG << "Hello log!"; // long macro
-    LOG(plog::debug) << "Hello log!"; // function-style macro
+    PLOGD << "Hello log!"; // short macro
+    PLOG_DEBUG << "Hello log!"; // long macro
+    PLOG(plog::debug) << "Hello log!"; // function-style macro
 
     // Log severity levels.
-    LOG_VERBOSE << "This is a VERBOSE message";
-    LOG_DEBUG << "This is a DEBUG message";
-    LOG_INFO << "This is an INFO message";
-    LOG_WARNING << "This is a WARNING message";
-    LOG_ERROR << "This is an ERROR message";
-    LOG_FATAL << "This is a FATAL message";
-    LOG_NONE << "This is a NONE message";
+    PLOG_VERBOSE << "This is a VERBOSE message";
+    PLOG_DEBUG << "This is a DEBUG message";
+    PLOG_INFO << "This is an INFO message";
+    PLOG_WARNING << "This is a WARNING message";
+    PLOG_ERROR << "This is an ERROR message";
+    PLOG_FATAL << "This is a FATAL message";
+    PLOG_NONE << "This is a NONE message";
 
     // Integers demo.
-    LOG_INFO << "This is a bool: " << std::boolalpha << true;
-    LOG_INFO << "This is a char: " << 'x';
-    LOG_INFO << "This is an unsigned char: " << (unsigned char)40;
-    LOG_INFO << "This is a short: " << (short)-1000;
-    LOG_INFO << "This is an unsigned short: " << (unsigned short)1000;
-    LOG_INFO << "This is an int: " << (int)-1000000;
-    LOG_INFO << "This is an unsigned int: " << (unsigned int)1000000;
-    LOG_INFO << "This is a long(hex): " << std::hex << (long)100000000;
-    LOG_INFO << "This is an unsigned long: " << (unsigned long)100000000;
-    LOG_INFO << "This is a float: " << 1.2345f;
-    LOG_INFO << "This is a double: " << std::setprecision(15) << 1.234512345;
+    PLOG_INFO << "This is a bool: " << std::boolalpha << true;
+    PLOG_INFO << "This is a char: " << 'x';
+    PLOG_INFO << "This is an unsigned char: " << (unsigned char)40;
+    PLOG_INFO << "This is a short: " << (short)-1000;
+    PLOG_INFO << "This is an unsigned short: " << (unsigned short)1000;
+    PLOG_INFO << "This is an int: " << (int)-1000000;
+    PLOG_INFO << "This is an unsigned int: " << (unsigned int)1000000;
+    PLOG_INFO << "This is a long(hex): " << std::hex << (long)100000000;
+    PLOG_INFO << "This is an unsigned long: " << (unsigned long)100000000;
+    PLOG_INFO << "This is a float: " << 1.2345f;
+    PLOG_INFO << "This is a double: " << std::setprecision(15) << 1.234512345;
 
     // Managed string.
 #ifdef __cplusplus_cli
     System::String^ managedStr = "This is a managed string";
-    LOG_INFO << managedStr;
+    PLOG_INFO << managedStr;
 #endif
 
     // Null strings are safe.
-    LOG_DEBUG << static_cast<char*>(NULL);
-    LOG_DEBUG << static_cast<const char*>(NULL);
+    PLOG_DEBUG << static_cast<char*>(NULL);
+    PLOG_DEBUG << static_cast<const char*>(NULL);
 
 #if PLOG_ENABLE_WCHAR_INPUT
-    LOG_DEBUG << static_cast<wchar_t*>(NULL);
-    LOG_DEBUG << static_cast<const wchar_t*>(NULL);
+    PLOG_DEBUG << static_cast<wchar_t*>(NULL);
+    PLOG_DEBUG << static_cast<const wchar_t*>(NULL);
 #endif
 
     // Plog handles unicode and std::string/wstring.
 #ifndef _WIN32 // On Windows the following code produces a warning C4566 if the codepage is not Cyrillic.
-    LOG_DEBUG << "Cat - котэ";
-    LOG_DEBUG << std::string("test - тест");
+    PLOG_DEBUG << "Cat - котэ";
+    PLOG_DEBUG << std::string("test - тест");
 #endif
 
 #if PLOG_ENABLE_WCHAR_INPUT
-    LOG_DEBUG << L"Cat - котэ";
-    LOG_DEBUG << std::wstring(L"test - тест");
-    LOG_DEBUG << L'ы';
+    PLOG_DEBUG << L"Cat - котэ";
+    PLOG_DEBUG << std::wstring(L"test - тест");
+    PLOG_DEBUG << L'ы';
 #endif
 
     // Multiline.
-    LOG_INFO << "This\nis\na" << std::endl << "multiline\nmessage!";
+    PLOG_INFO << "This\nis\na" << std::endl << "multiline\nmessage!";
 
     // Quotes.
-    LOG_INFO << "This is a message with \"quotes\"!";
+    PLOG_INFO << "This is a message with \"quotes\"!";
 
     // Conditional logging.
     int var = 0;
-    LOG_DEBUG_IF(var != 0) << "You shouldn't see this message";
-    LOG_DEBUG_IF(var == 0) << "This is a conditional log message";
+    PLOG_DEBUG_IF(var != 0) << "You shouldn't see this message";
+    PLOG_DEBUG_IF(var == 0) << "This is a conditional log message";
 
     // Executed only on log level >= debug.
-    IF_LOG(plog::debug) var = 5; // one line
-    IF_LOG(plog::debug) // block
+    IF_PLOG(plog::debug) var = 5; // one line
+    IF_PLOG(plog::debug) // block
     {
         var++;
     }
 
     // Log macros don't break then-else clause without braces.
-    if (var == 0) LOGI << "then clause (condition is false, so it is skipped)"; else LOGI << "else clase (should be visible)";
+    if (var == 0) PLOGI << "then clause (condition is false, so it is skipped)"; else PLOGI << "else clase (should be visible)";
 
     // Log in a class (capture this pointer, c++ function names).
     MyClass obj;
@@ -93,11 +93,11 @@ int main()
     MyClass::staticMethod();
 
     // Implicit cast to string.
-    LOG_INFO << obj;
+    PLOG_INFO << obj;
 
     // ostream operator<< (on Windows wostream operator<< has priority but not required)
     Customer customer = { 10, "John" };
-    LOG_INFO << customer;
+    PLOG_INFO << customer;
 
     return 0;
 }

--- a/samples/Demo/MyClass.cpp
+++ b/samples/Demo/MyClass.cpp
@@ -2,22 +2,22 @@
 
 MyClass::MyClass()
 {
-    LOGD;
+    PLOGD;
 }
 
 MyClass::~MyClass()
 {
-    LOGD;
+    PLOGD;
 }
 
 void MyClass::method()
 {
-    LOGD;
+    PLOGD;
 }
 
 void MyClass::staticMethod()
 {
-    LOGD;
+    PLOGD;
 }
 
 MyClass::operator std::string() const

--- a/samples/Demo/MyClass.h
+++ b/samples/Demo/MyClass.h
@@ -11,7 +11,7 @@ public:
 
     void inlineMethod()
     {
-        LOGD;
+        PLOGD;
     }
 
     static void staticMethod();

--- a/samples/EventLog/Main.cpp
+++ b/samples/EventLog/Main.cpp
@@ -49,12 +49,12 @@ int main(int argc, char* argv[])
     static plog::EventLogAppender<plog::MessageOnlyFormatter> eventLogAppender(kEventSourceName);
     plog::init(plog::verbose, &eventLogAppender);
 
-    LOG_VERBOSE << "This is a VERBOSE message";
-    LOG_DEBUG << "This is a DEBUG message";
-    LOG_INFO << "This is an INFO message";
-    LOG_WARNING << "This is a WARNING message";
-    LOG_ERROR << "This is an ERROR message";
-    LOG_FATAL << "This is a FATAL message";
+    PLOG_VERBOSE << "This is a VERBOSE message";
+    PLOG_DEBUG << "This is a DEBUG message";
+    PLOG_INFO << "This is an INFO message";
+    PLOG_WARNING << "This is a WARNING message";
+    PLOG_ERROR << "This is an ERROR message";
+    PLOG_FATAL << "This is a FATAL message";
 
     return 0;
 }

--- a/samples/Facilities/Main.cpp
+++ b/samples/Facilities/Main.cpp
@@ -21,11 +21,11 @@ int main()
     plog::init<Auth>(plog::warning, plog::get<Sink>());
     plog::init<FileIO>(plog::info, plog::get<Sink>());
 
-    LOGD_(Default) << "This is a message from the Default facility";
-    LOGD << "This is a message from the Default facility too because Default = 0";
+    PLOGD_(Default) << "This is a message from the Default facility";
+    PLOGD << "This is a message from the Default facility too because Default = 0";
 
-    LOGW_(Auth) << "This is a message from the Auth facility";
-    LOGI_(FileIO) << "This is a message from the FileIO facility";
+    PLOGW_(Auth) << "This is a message from the Auth facility";
+    PLOGI_(FileIO) << "This is a message from the FileIO facility";
 
     return 0;
 }

--- a/samples/Hello/Main.cpp
+++ b/samples/Hello/Main.cpp
@@ -10,9 +10,9 @@ int main()
 
     // Step3: write log messages using a special macro. There are several log macros, use the macro you liked the most.
 
-    LOGD << "Hello log!"; // short macro
-    LOG_DEBUG << "Hello log!"; // long macro
-    LOG(plog::debug) << "Hello log!"; // function-style macro
+    PLOGD << "Hello log!"; // short macro
+    PLOG_DEBUG << "Hello log!"; // long macro
+    PLOG(plog::debug) << "Hello log!"; // function-style macro
 
     return 0;
 }

--- a/samples/Library/LibraryApp/Main.cpp
+++ b/samples/Library/LibraryApp/Main.cpp
@@ -13,7 +13,7 @@ int main()
 
     foo();
 
-    LOGD << "A message from the main application!";
+    PLOGD << "A message from the main application!";
 
     return 0;
 }

--- a/samples/Library/LibraryLib/Lib.cpp
+++ b/samples/Library/LibraryLib/Lib.cpp
@@ -7,5 +7,5 @@
 void foo()
 {
     // The logger is initialized in the main app. It is safe not to do that and even not to use plog at all. The library will be linked fine.
-    LOGD << "A message from the static library!";
+    PLOGD << "A message from the static library!";
 }

--- a/samples/MultiAppender/Main.cpp
+++ b/samples/MultiAppender/Main.cpp
@@ -14,7 +14,7 @@ int main()
     // A bunch of log lines that goes to the both appenders: to the file and to the console.
     for (int i = 0; i < 100; ++i)
     {
-        LOG_INFO << "i: " << i;
+        PLOG_INFO << "i: " << i;
     }
 
     return 0;

--- a/samples/MultiInstance/Main.cpp
+++ b/samples/MultiInstance/Main.cpp
@@ -15,14 +15,14 @@ int main()
     plog::init<SecondLog>(plog::debug, "MultiInstance-second.txt"); // Initialize the 2nd logger instance.
 
     // Write some messages to the default log.
-    LOGD << "Hello default log!";
-    LOG_DEBUG << "Hello default log!";
-    LOG(plog::debug) << "Hello default log!";
+    PLOGD << "Hello default log!";
+    PLOG_DEBUG << "Hello default log!";
+    PLOG(plog::debug) << "Hello default log!";
 
     // Write some messages to the 2nd log.
-    LOGD_(SecondLog) << "Hello second log!";
-    LOG_DEBUG_(SecondLog) << "Hello second log!";
-    LOG_(SecondLog, plog::debug) << "Hello second log!";
+    PLOGD_(SecondLog) << "Hello second log!";
+    PLOG_DEBUG_(SecondLog) << "Hello second log!";
+    PLOG_(SecondLog, plog::debug) << "Hello second log!";
 
     return 0;
 }

--- a/samples/NativeEOL/Main.cpp
+++ b/samples/NativeEOL/Main.cpp
@@ -14,7 +14,7 @@ int main()
     // Write some data.
     for (int i = 0; i < 100; ++i)
     {
-        LOGI << "i: " << i;
+        PLOGI << "i: " << i;
     }
 
     return 0;

--- a/samples/ObjectiveC/Main.mm
+++ b/samples/ObjectiveC/Main.mm
@@ -15,14 +15,14 @@
 @implementation Greeter
 +(void) greet
 {
-    LOGD << "Hello ObjC++!";
+    PLOGD << "Hello ObjC++!";
 }
 @end
 
 int main()
 {
     plog::init(plog::debug, "ObjectiveC.csv"); // Initialize the logger.
-    LOGD << "Hello ObjC++!";
+    PLOGD << "Hello ObjC++!";
     
     [Greeter greet];
     

--- a/samples/Performance/Main.cpp
+++ b/samples/Performance/Main.cpp
@@ -19,7 +19,7 @@ int main()
     static plog::ConsoleAppender<plog::TxtFormatter> consoleAppender;
     plog::init<Console>(plog::debug, &consoleAppender);
 
-    LOGI_(Console) << "Test started";
+    PLOGI_(Console) << "Test started";
 
     plog::util::Time startTime;
     plog::util::ftime(&startTime);
@@ -29,7 +29,7 @@ int main()
     // Performance measure loop.
     for (int i = 0; i < kCount; ++i)
     {
-        LOGD << "Hello log!";
+        PLOGD << "Hello log!";
     }
 
     plog::util::Time finishTime;
@@ -37,7 +37,7 @@ int main()
 
     time_t timeDiff = (finishTime.millitm - startTime.millitm) + (finishTime.time - startTime.time) * 1000;
 
-    LOGI_(Console) << "Test finished: " << static_cast<double>(timeDiff) * 1000 / kCount << " microsec per call";
+    PLOGI_(Console) << "Test finished: " << static_cast<double>(timeDiff) * 1000 / kCount << " microsec per call";
 
     return 0;
 }

--- a/samples/UtcTime/Main.cpp
+++ b/samples/UtcTime/Main.cpp
@@ -12,12 +12,12 @@ int main()
     static plog::RollingFileAppender<plog::CsvFormatterUtcTime> fileAppender("UtcTime.csv", 10000, 2); // CsvFormatter in UTC
     plog::init(plog::verbose, &consoleAppender).addAppender(&fileAppender);
 
-    LOG_VERBOSE << "This is a VERBOSE message";
-    LOG_DEBUG << "This is a DEBUG message";
-    LOG_INFO << "This is an INFO message";
-    LOG_WARNING << "This is a WARNING message";
-    LOG_ERROR << "This is an ERROR message";
-    LOG_FATAL << "This is a FATAL message";
+    PLOG_VERBOSE << "This is a VERBOSE message";
+    PLOG_DEBUG << "This is a DEBUG message";
+    PLOG_INFO << "This is an INFO message";
+    PLOG_WARNING << "This is a WARNING message";
+    PLOG_ERROR << "This is an ERROR message";
+    PLOG_FATAL << "This is a FATAL message";
 
     return 0;
 }


### PR DESCRIPTION
…flicts with "LOG" names defined in other packages or in system headers.

For compatibility with existing Plog users that use the "LOG" names, 
continue to define old "LOG" names unless PLOG_OMIT_LOG_DEFINES has been 
defined.