### PR TITLE
Return 0 when platform is unknown in util::gettid

### DIFF
--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -127,6 +127,8 @@ namespace plog
             uint64_t tid64;
             pthread_threadid_np(NULL, &tid64);
             return static_cast<unsigned int>(tid64);
+#else
+            return 0;
 #endif
         }
 


### PR DESCRIPTION
Hello, thank you for the project!

This pull request adds `#else` to `util::getiid` and makes it return 0 by default.
This fixes "control reaches end of non-void function" warnings in some platforms (e.g., Emscripten).
