### PR TITLE
Bump minimum cmake version (2.8->3.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 option(PLOG_BUILD_SAMPLES "Build plog's samples." ON)
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 if(POLICY CMP0063) #Honor visibility properties for all target types
     cmake_policy(SET CMP0063 NEW)


### PR DESCRIPTION
to suppress cmake deprecation warning. See #175 for the rationale of this pull request,