### PR TITLE
Allows to remove appender

### DIFF
--- a/include/plog/Appenders/IAppender.h
+++ b/include/plog/Appenders/IAppender.h
@@ -12,5 +12,6 @@ namespace plog
         }
 
         virtual void write(const Record& record) = 0;
+		virtual std::string getAppenderName() { return "";}
     };
 }

--- a/include/plog/Logger.h
+++ b/include/plog/Logger.h
@@ -28,6 +28,13 @@ namespace plog
             return *this;
         }
 
+        Logger& removeAppender(const std::string& name)
+        {
+            assert(!name.empty());
+			m_appenders.erase(std::remove_if(m_appenders.begin(), m_appenders.end(), [&name](IAppender * appender){return appender->getAppenderName() == name;}),m_appenders.end());
+            return *this;
+        }
+		
         Severity getMaxSeverity() const
         {
             return m_maxSeverity;


### PR DESCRIPTION
For some reasons, I had to load/unload my appenders. Here how I have done.

I have added a removeAppender method in order to remove appender by its name. Then I put a getAppenderName method in Appender interface that returns an empty string if we don't overload it.
 