### PR TITLE
Implementation of vasprintf emulation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run: cmake -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE && cd build && make -j
   platformio:
     docker:
-      - image: sergiusthebest/platformio-ci:latest
+      - image: ghcr.io/sergiusthebest/platformio-ci:latest
     steps:
       - checkout
       - run: pio run -d samples/Arduino

--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -189,6 +189,10 @@ namespace plog
 #endif
         }
 
+#if defined(_MSC_VER) && _MSC_VER <= 1600
+#   define va_copy(d,s) ((d)=(s)) // there is no va_copy on Visual Studio 2010
+#endif
+
 #ifndef _GNU_SOURCE
     inline int vasprintf(char** strp, const char* format, va_list ap)
     {

--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -193,12 +193,16 @@ namespace plog
 #   define va_copy(d,s) ((d)=(s)) // there is no va_copy on Visual Studio 2010
 #endif
 
+#ifndef __STDC_SECURE_LIB__
+#   define vsnprintf_s(buf,cnt,max,fmt,ap) vsnprintf((buf),(cnt),(fmt),(ap));
+#endif
+
 #ifndef _GNU_SOURCE
     inline int vasprintf(char** strp, const char* format, va_list ap)
     {
         va_list ap_copy;
         va_copy(ap_copy, ap);
-        int charCount = vsnprintf(NULL, 0, format, ap_copy);
+        int charCount = vsnprintf_s(NULL, 0, static_cast<size_t>(-1), format, ap_copy);
         va_end(ap_copy);
         if (charCount < 0)
         {
@@ -213,7 +217,7 @@ namespace plog
             return -1;
         }
 
-        int retval = vsnprintf(str, bufferCharCount, format, ap);
+        int retval = vsnprintf_s(str, bufferCharCount, static_cast<size_t>(-1), format, ap);
         if (retval < 0)
         {
             free(str);

--- a/samples/Arduino/platformio.ini
+++ b/samples/Arduino/platformio.ini
@@ -20,3 +20,8 @@ framework = arduino
 platform = espressif32
 board = esp32dev
 framework = arduino
+
+[env:pico]
+platform = raspberrypi
+board = pico
+framework = arduino


### PR DESCRIPTION
vasprintf for `_WIN32` or non `_GNU_SOURCE` should be consolidated in this way.

vsnprintf here is a part of old C standards, so it will probably work in all environments that plog should support.

I've roughly confirmed that can build in the following environments, but more testing might be needed.

- gcc/g++ MSYS2
- VC++2022
- Embarcadero C++Builder Community Edition
- PlatformIO, for boards listed in `platformio.ini`

Related issues:

- #113
- #229