### PR TITLE
Templated class are not properly parsed.

### DIFF
--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -196,7 +196,7 @@ namespace plog
 #if defined(_MSC_VER) && _MSC_VER <= 1600
         ap_copy = ap; // there is no va_copy on Visual Studio 2010
 #else
-        va_copy(ap_copy, ap);        
+        va_copy(ap_copy, ap);
 #endif
 #ifndef __STDC_SECURE_LIB__
         int charCount = vsnprintf(NULL, 0, format, ap_copy);
@@ -349,13 +349,15 @@ namespace plog
 
             for (const char* i = funcEnd - 1; i >= funcBegin; --i) // search backwards for the first space char
             {
-                if (*i == '>') {
+                if (*i == '>')
+                {
                     foundTemplate++;
                 }
-                if (*i == '<') {
+                else if (*i == '<')
+                {
                     foundTemplate--;
                 }
-                if (*i == ' ' && foundTemplate == 0)
+                else if (*i == ' ' && foundTemplate == 0)
                 {
                     funcBegin = i + 1;
                     break;

--- a/include/plog/Util.h
+++ b/include/plog/Util.h
@@ -340,6 +340,7 @@ namespace plog
 #else
             const char* funcBegin = func;
             const char* funcEnd = ::strchr(funcBegin, '(');
+            int foundTemplate = 0;
 
             if (!funcEnd)
             {
@@ -348,7 +349,13 @@ namespace plog
 
             for (const char* i = funcEnd - 1; i >= funcBegin; --i) // search backwards for the first space char
             {
-                if (*i == ' ')
+                if (*i == '>') {
+                    foundTemplate++;
+                }
+                if (*i == '<') {
+                    foundTemplate--;
+                }
+                if (*i == ' ' && foundTemplate == 0)
                 {
                     funcBegin = i + 1;
                     break;

--- a/samples/Demo/Main.cpp
+++ b/samples/Demo/Main.cpp
@@ -130,6 +130,9 @@ int main()
 
     MyClass::staticMethod();
 
+    // Log in a template class.
+    MyTemplateClass(1, 2).inlineMethod();
+
     // Implicit cast to string.
     PLOG_INFO << obj;
 

--- a/samples/Demo/Main.cpp
+++ b/samples/Demo/Main.cpp
@@ -131,7 +131,7 @@ int main()
     MyClass::staticMethod();
 
     // Log in a template class.
-    MyTemplateClass(1, 2).inlineMethod();
+    MyTemplateClass<int, int>(1, 2).inlineMethod();
 
     // Implicit cast to string.
     PLOG_INFO << obj;

--- a/samples/Demo/MyClass.h
+++ b/samples/Demo/MyClass.h
@@ -18,3 +18,22 @@ public:
 
     operator std::string() const;
 };
+
+template <typename T, typename U>
+class MyTemplateClass
+{
+public:
+    MyTemplateClass(T t1, U t2)
+        : m_t1(t1)
+        , m_t2(t2)
+    {
+    }
+
+    inline void inlineMethod()
+    {
+        PLOGD;
+    }
+private:
+    T m_t1;
+    U m_t2;
+};


### PR DESCRIPTION
The function names of the class templates are badly parsed, as the `>` character is not processed.

For example, the following example log

```C++
template <typename T, typename U>
class MyTemplateClass
{
public:
    MyTemplateClass(T t1, U t2)
        : m_t1(t1)
        , m_t2(t2)
    {
    }

    inline void inlineMethod()
    {
        PLOGD;
    }
private:
    T m_t1;
    U m_t2;
};

MyTemplateClass(1, 2).inlineMethod();
```

```
2023-04-20 12:12:44.836 DEBUG [97136] [U>::inlineMethod@34]
```
instead of
```
2023-04-20 12:12:44.836 DEBUG [97136] [MyTemplateClass<T, U>::inlineMethod@34]
```