### PR TITLE
fix typo in test/CMakeLists.txt

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,7 +69,7 @@ function(plog_add_test_wchar _target)
         target_compile_definitions(${_target} PRIVATE PLOG_ENABLE_WCHAR_INPUT=1)
 
         if(APPLE)
-            target_link_libraries(${_target}_wchar -liconv)
+            target_link_libraries(${_target} -liconv)
         endif()
     endif()
 endfunction()


### PR DESCRIPTION
[ENV]
Machine: MacBook Air (M1, 2020)
OS: macOS Monterey 12.3
Compiler: AppleClang 13.0.0.13000027
CMake: 3.23.3

[Reproduce]
- create build folder in plog
- in plog/build, got error when typing "cmake -DPLOG_BUILD_TESTS=ON .."
<img width="671" alt="截圖 2023-11-13 上午2 18 46" src="https://github.com/SergiusTheBest/plog/assets/150613254/e9eaabe6-03c0-4b49-95d5-72d6b453f820">

[Results]
should be typo in test/CMakeLists.txt, fix and build successfully.