### PR TITLE
(cmake) Minimum required version as of `cmake` 3.31

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 if(${CMAKE_VERSION} VERSION_LESS 3.27.0)
     cmake_minimum_required(VERSION 3.0)
-else()
+elseif(${CMAKE_VERSION} VERSION_LESS 3.31.0)
     cmake_minimum_required(VERSION 3.6)
+else()
+    cmake_minimum_required(VERSION 3.10)
 endif()
 
 project(plog VERSION 1.1.10 LANGUAGES CXX)


### PR DESCRIPTION
We're seeing this error after updating to `cmake` 3.31:

```
INFO:root:CMake version:
cmake version 3.31.2

CMake Deprecation Error at external/plog/CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
```

This PR is thus an update to the logic on the "minimum required version" logic on the first few lines in `CMakeLists.txt`.

For reference, the release notes for `CMake` 3.31, stating the change in the min required version, are here:
- https://cmake.org/cmake/help/latest/release/3.31.html 