### PR TITLE
Update CI scripts (deal with deprecated OS versions)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,8 +2,8 @@ task:
     name: FreeBSD
     freebsd_instance:
         matrix:
-            - image_family: freebsd-13-3
-            - image_family: freebsd-14-0
+            - image_family: freebsd-13-5
+            - image_family: freebsd-14-3
             - image_family: freebsd-15-0-snap
     matrix:
         - BUILD_TYPE: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: Reusable build workflow (hack to be able to skip container image)
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: Image to use for the job. If image is 'null' it will execute directly on the runner.
+        type: string
+        required: false
+        default: null
+      os:
+        description: OS to use for the job.
+        type: string
+        required: false
+        default: ubuntu--latest
+      cxx:
+        description: CXX to use for the job.
+        type: string
+        required: false
+        default: null
+      generator:
+        description: Cmake generator to use for the job.
+        type: string
+        required: false
+        default: null
+jobs:
+  build:
+    runs-on: ${{ inputs.os }}
+    container:
+      image: ${{ inputs.image }}
+      options: --user root
+    env:
+      CXX: ${{ inputs.cxx }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1 # https://github.com/actions/checkout/issues/1590
+      with:
+        fetch-depth: 0
+
+    - name: Build
+      run: |
+        cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DPLOG_BUILD_TESTS=ON ${{ inputs.generator }} .
+        cmake --build build --parallel
+
+    - name: Test
+      run: cd build && ctest -V

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,13 @@ jobs:
           { os: ubuntu-24.04,   cxx: g++-14,      pkgs: '' }, # (default on Noble 24.04)
           { os: ubuntu-22.04,   cxx: g++-11,      pkgs: '' }, # (default on Jammy 22.04)
           { os: ubuntu-22.04,   cxx: g++-9,       pkgs: '' }, # (default on Focal 20.04)
-          { os: ubuntu-20.04,   cxx: g++-7,       pkgs: 'g++-7' }, # (default on Bionic 18.04)
-          { os: ubuntu-20.04,   cxx: g++-5,       pkgs: 'g++-5',   repo: 'xenial' }, # (default on Xenial 16.04)
-          { os: ubuntu-20.04,   cxx: g++-4.8,     pkgs: 'g++-4.8', repo: 'trusty' }, # (default on Trusty 14.04)
+          { os: ubuntu-22.04,   cxx: g++-7,       pkgs: 'g++-7' }, # (default on Bionic 18.04)
+          { os: ubuntu-22.04,   cxx: g++-5,       pkgs: 'g++-5',   repo: 'xenial' }, # (default on Xenial 16.04)
+          { os: ubuntu-22.04,   cxx: g++-4.8,     pkgs: 'g++-4.8', repo: 'trusty' }, # (default on Trusty 14.04)
           # linux: clang
+          { os: ubuntu-24.04,   cxx: clang++-18,  pkgs: '' },
           { os: ubuntu-22.04,   cxx: clang++-14,  pkgs: '' },
-          { os: ubuntu-20.04,   cxx: clang++-10,  pkgs: '' },
-          { os: ubuntu-20.04,   cxx: clang++-6.0, pkgs: 'clang-6.0' },
+          { os: ubuntu-22.04,   cxx: clang++-6.0, pkgs: 'clang-6.0' },
           # windows: msvc
           { os: windows-2019,   cxx: 'vs2019' },
           { os: windows-2022,   cxx: 'vs2022' },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,13 @@ jobs:
           { os: ubuntu-24.04,   cxx: g++-14,      pkgs: '' }, # (default on Noble 24.04)
           { os: ubuntu-22.04,   cxx: g++-11,      pkgs: '' }, # (default on Jammy 22.04)
           { os: ubuntu-22.04,   cxx: g++-9,       pkgs: '' }, # (default on Focal 20.04)
-          { os: ubuntu-22.04,   cxx: g++-7,       pkgs: 'g++-7' }, # (default on Bionic 18.04)
-          { os: ubuntu-22.04,   cxx: g++-5,       pkgs: 'g++-5',   repo: 'xenial' }, # (default on Xenial 16.04)
-          { os: ubuntu-22.04,   cxx: g++-4.8,     pkgs: 'g++-4.8', repo: 'trusty' }, # (default on Trusty 14.04)
+          #{ os: ubuntu-22.04,   cxx: g++-7,       pkgs: 'g++-7' }, # (default on Bionic 18.04)
+          #{ os: ubuntu-22.04,   cxx: g++-5,       pkgs: 'g++-5',   repo: 'xenial' }, # (default on Xenial 16.04)
+          #{ os: ubuntu-22.04,   cxx: g++-4.8,     pkgs: 'g++-4.8', repo: 'trusty' }, # (default on Trusty 14.04)
           # linux: clang
           { os: ubuntu-24.04,   cxx: clang++-18,  pkgs: '' },
           { os: ubuntu-22.04,   cxx: clang++-14,  pkgs: '' },
-          { os: ubuntu-22.04,   cxx: clang++-6.0, pkgs: 'clang-6.0' },
+          #{ os: ubuntu-22.04,   cxx: clang++-6.0, pkgs: 'clang-6.0' },
           # windows: msvc
           { os: windows-2019,   cxx: 'vs2019' },
           { os: windows-2022,   cxx: 'vs2022' },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,61 +35,27 @@ jobs:
       fail-fast: true
       matrix:
         include: [
-          # You can access the following values via ${{ matrix.??? }}
-          #
-          #   pkgs         : apt-get package names separated by space
-          #   cxx          : C++ compiler executable
-          #   os           : GitHub Actions YAML workflow label.  See https://github.com/actions/virtual-environments#available-environments
-
           # linux: gcc
-          { os: ubuntu-24.04,   cxx: g++-14,      pkgs: '' }, # (default on Noble 24.04)
-          { os: ubuntu-22.04,   cxx: g++-11,      pkgs: '' }, # (default on Jammy 22.04)
-          { os: ubuntu-22.04,   cxx: g++-9,       pkgs: '' }, # (default on Focal 20.04)
-          #{ os: ubuntu-22.04,   cxx: g++-7,       pkgs: 'g++-7' }, # (default on Bionic 18.04)
-          #{ os: ubuntu-22.04,   cxx: g++-5,       pkgs: 'g++-5',   repo: 'xenial' }, # (default on Xenial 16.04)
-          #{ os: ubuntu-22.04,   cxx: g++-4.8,     pkgs: 'g++-4.8', repo: 'trusty' }, # (default on Trusty 14.04)
+          { os: ubuntu-24.04,   cxx: g++-14 }, # (default on Noble 24.04)
+          { os: ubuntu-22.04,   cxx: g++-11 }, # (default on Jammy 22.04)
+          { os: ubuntu-22.04,   cxx: g++-9  }, # (default on Focal 20.04)
+          { os: ubuntu-latest,  cxx: g++-7,       image: conanio/gcc7 }, # (default on Focal 20.04)
+          { os: ubuntu-latest,  cxx: g++-5,       image: conanio/gcc5 }, # (default on Xenial 16.04)
+          { os: ubuntu-latest,  cxx: g++-4.8,     image: conanio/gcc48 }, # (default on Trusty 14.04)
           # linux: clang
-          { os: ubuntu-24.04,   cxx: clang++-18,  pkgs: '' },
-          { os: ubuntu-22.04,   cxx: clang++-14,  pkgs: '' },
-          #{ os: ubuntu-22.04,   cxx: clang++-6.0, pkgs: 'clang-6.0' },
+          { os: ubuntu-24.04,   cxx: clang++-18 },
+          { os: ubuntu-latest,  cxx: clang++-6.0, image: conanio/clang60 },
           # windows: msvc
-          { os: windows-2019,   cxx: 'vs2019' },
-          { os: windows-2022,   cxx: 'vs2022' },
+          # unfortunately, Visual Studio 2019 is not available on github-hosted runners anymore
+          { os: windows-2022,   cxx: vs2022-x86,  generator: '-G "Visual Studio 17 2022" -A Win32' },
+          { os: windows-2022,   cxx: vs2022-x64,  generator: '-G "Visual Studio 17 2022" -A x64' },
           # macos: clang
           { os: macos-13,       cxx: 'clang++' }
         ]
 
-    runs-on: ${{ matrix.os }}
-
-    env:
-      CXX: ${{ matrix.cxx }}
-
-    steps:
-    - name: checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    # workaround for broken clang on ubuntu runner until https://github.com/actions/runner-images/issues/8659 get fixed
-    - uses: mjp41/workaround8649@c8550b715ccdc17f89c8d5c28d7a48eeff9c94a8
-      with:
-        os: ${{ matrix.os }}
-
-    - name: apt/sources.list.d
-      if: ${{ matrix.repo != '' }}
-      run: |
-        echo "deb http://archive.ubuntu.com/ubuntu ${{ matrix.repo }} main" | sudo tee /etc/apt/sources.list.d/${{ matrix.repo }}.list
-
-    - name: apt-get install
-      if: ${{ matrix.pkgs != '' }}
-      run: |
-        sudo apt-get update
-        sudo apt-get install ${{ matrix.pkgs }}
-
-    - name: build
-      run: |
-        cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DPLOG_BUILD_TESTS=1 .
-        cmake --build build --parallel
-
-    - name: test
-      run: cd build && ctest -V
+    uses: ./.github/workflows/build.yml
+    with:
+      image: ${{ matrix.image }}
+      os: ${{ matrix.os }}
+      cxx: ${{ matrix.cxx }}
+      generator: ${{ matrix.generator }}

--- a/samples/FreeRTOS/CMakeLists.txt
+++ b/samples/FreeRTOS/CMakeLists.txt
@@ -1,4 +1,13 @@
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(POLICY CMP0135) # Controls timestamps of the extracted contents (DOWNLOAD_EXTRACT_TIMESTAMP)
+        cmake_policy(SET CMP0135 NEW)
+    endif()
+
+    # This sample requires GCC 6.0 or later
+    if(NOT CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
+        return()
+    endif()
+
     include(FetchContent)
 
     # Select FreeRTOS port
@@ -15,7 +24,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         freertos_kernel
         URL                        https://github.com/FreeRTOS/FreeRTOS-Kernel/archive/refs/tags/V11.1.0.tar.gz
         URL_HASH                   SHA256=0e21928b3bcc4f9bcaf7333fb1c8c0299d97e2ec9e13e3faa2c5a7ac8a3bc573
-        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     )
 
     FetchContent_MakeAvailable(freertos_kernel)


### PR DESCRIPTION
- **Extracted reusable workflow**: Created a new `.github/workflows/build.yml` as a reusable workflow to eliminate code duplication
- **Container-based builds**: Introduced Docker container support for older GCC/Clang versions using Conan.io images instead of managing Ubuntu package repositories
- **Eliminated direct Ubuntu 20.04 usage** from the CI matrix
- **GCC versions**: Maintained support for GCC 4.8, 5, 7, 9, 11, and 14 through container images
- **Clang versions**: Updated to include Clang 18 and maintained Clang 6.0 support via containers
- **Windows builds**: Updated to use Visual Studio 2022 with both x86 and x64 architectures (removed VS2019 due to GitHub runner deprecation)
- **Updated FreeBSD versions**: 
  - `freebsd-13-3` → `freebsd-13-5`
  - `freebsd-14-0` → `freebsd-14-3`
  - Maintained `freebsd-15-0-snap` for bleeding-edge testing