### PR TITLE
some bugfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 if(${CMAKE_VERSION} VERSION_LESS 3.27.0)
     cmake_minimum_required(VERSION 3.0)
-elseif(${CMAKE_VERSION} VERSION_LESS 3.31.0)
-    cmake_minimum_required(VERSION 3.6)
 else()
     cmake_minimum_required(VERSION 3.10)
 endif()

--- a/samples/HexDump/Main.cpp
+++ b/samples/HexDump/Main.cpp
@@ -39,6 +39,6 @@ int main()
 
     void* p = malloc(100);
     PLOGI << "p: " << plog::hexdump(p, 100);
-
+    free(p);
     return 0;
 }


### PR DESCRIPTION
- Fixes #303
- Removes `${CMAKE_VERSION} VERSION_LESS 3.31.0`:
> Changed in version 3.31: Compatibility with versions of CMake older than 3.10 is deprecated. Calls to [cmake_minimum_required(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_policy.html#version) that do not specify at least 3.10 as their policy version (optionally via ...<max>) will produce a deprecation warning in CMake 3.31 and above.

That doesn't make an error - it makes an warning.