### PR TITLE
cmake: this project is ARCH_INDEPENDENT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ if(PLOG_INSTALL)
 
     install(
         EXPORT ${PROJECT_NAME}Config
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+        DESTINATION share/cmake/${PROJECT_NAME}
         NAMESPACE ${PROJECT_NAME}::
     )
 
@@ -77,10 +77,11 @@ if(PLOG_INSTALL)
     write_basic_package_version_file(
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
         COMPATIBILITY AnyNewerVersion
+        ARCH_INDEPENDENT
     )
 
     install(
         FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+        DESTINATION share/cmake/${PROJECT_NAME}
     )
 endif()


### PR DESCRIPTION
With these small changes, the cmake files `plogConfig.cmake` & `plogConfigVersion.cmake` will be installed under `$PREFIX/share/cmake/plog` instead of `$LIBDIR/cmake/plog`

This helps Linux distributions with multiarch library path (like Debian or Ubuntu) so they can distribute one "_architecture: all_" package instead of a multitude of architecture specific packages with the same set of files