### PR TITLE
Make function name capture optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,7 +736,8 @@ public:
 - message
 - instance id
 
-> **Note** Source file name isn't captured by default. To enable it define PLOG_CAPTURE_FILE.
+> **Note** Source file name isn't captured by default. To enable it define `PLOG_CAPTURE_FILE`.
+> Function name is captured by default, to disable it define `PLOG_NO_CAPTURE_FUNCTION_NAME`.
 
 Also [Record](#record) has a number of overloaded stream output operators to construct a message.
 

--- a/include/plog/Log.h
+++ b/include/plog/Log.h
@@ -15,7 +15,9 @@
 #   define PLOG_GET_THIS()      reinterpret_cast<void*>(0)
 #endif
 
-#ifdef _MSC_VER
+#ifdef PLOG_NO_CAPTURE_FUNCTION_NAME
+#   define PLOG_GET_FUNC()      ""
+#elif defined(_MSC_VER)
 #   define PLOG_GET_FUNC()      __FUNCTION__
 #elif defined(__BORLANDC__)
 #   define PLOG_GET_FUNC()      __FUNC__

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,8 @@ set(SOURCES
     CastToString.cpp
     Common.h
     Conditional.cpp
+    FunctionNameEnabled.cpp
+    FunctionNameDisabled.cpp
     TestAppender.h
     Main.cpp
     MessagePrefix.cpp

--- a/test/FunctionNameDisabled.cpp
+++ b/test/FunctionNameDisabled.cpp
@@ -18,7 +18,7 @@ SCENARIO("disabling function name output")
 
             THEN("the function entry is empty")
             {
-                CHECK_EQ(testAppender.getFunc(), PLOG_NSTR(""));
+                CHECK_EQ(testAppender.getFunc(), "");
             }
         }
     }

--- a/test/FunctionNameDisabled.cpp
+++ b/test/FunctionNameDisabled.cpp
@@ -1,0 +1,25 @@
+#define PLOG_NO_CAPTURE_FUNCTION_NAME
+
+#include "Common.h"
+#include <vector>
+#include <utility>
+
+SCENARIO("disabling function name output")
+{
+    GIVEN("logger is initialised")
+    {
+        plog::TestAppender testAppender;
+        plog::Logger<PLOG_DEFAULT_INSTANCE_ID> logger(plog::verbose);
+        logger.addAppender(&testAppender);
+
+        WHEN("log message is created")
+        {
+            PLOGI << "Log message text";
+
+            THEN("the function entry is empty")
+            {
+                CHECK_EQ(testAppender.getFunc(), PLOG_NSTR(""));
+            }
+        }
+    }
+}

--- a/test/FunctionNameEnabled.cpp
+++ b/test/FunctionNameEnabled.cpp
@@ -1,0 +1,25 @@
+// Note: including the function name in the log Record is enabled
+// by default.
+#include "Common.h"
+#include <vector>
+#include <utility>
+
+SCENARIO("disabling function name output")
+{
+    GIVEN("logger is initialised")
+    {
+        plog::TestAppender testAppender;
+        plog::Logger<PLOG_DEFAULT_INSTANCE_ID> logger(plog::verbose);
+        logger.addAppender(&testAppender);
+
+        WHEN("log message is created")
+        {
+            PLOGI << "Log message text";
+
+            THEN("the function entry is not empty")
+            {
+                CHECK_NE(testAppender.getFunc(), PLOG_NSTR(""));
+            }
+        }
+    }
+}

--- a/test/FunctionNameEnabled.cpp
+++ b/test/FunctionNameEnabled.cpp
@@ -18,7 +18,7 @@ SCENARIO("disabling function name output")
 
             THEN("the function entry is not empty")
             {
-                CHECK_NE(testAppender.getFunc(), PLOG_NSTR(""));
+                CHECK_NE(testAppender.getFunc(), "");
             }
         }
     }

--- a/test/TestAppender.h
+++ b/test/TestAppender.h
@@ -17,13 +17,13 @@ namespace plog
             return m_message;
         }
 
-        const util::nstring& getFunc() const
+        const std::string& getFunc() const
         {
             return m_func;
         }
 
     private:
         util::nstring m_message;
-        util::nstring m_func;
+        std::string m_func;
     };
 }

--- a/test/TestAppender.h
+++ b/test/TestAppender.h
@@ -9,6 +9,7 @@ namespace plog
         virtual void write(const Record& record) PLOG_OVERRIDE
         {
             m_message = record.getMessage();
+            m_func = record.getFunc();
         }
 
         const util::nstring& getMessage() const
@@ -16,7 +17,13 @@ namespace plog
             return m_message;
         }
 
+        const util::nstring& getFunc() const
+        {
+            return m_func;
+        }
+
     private:
         util::nstring m_message;
+        util::nstring m_func;
     };
 }


### PR DESCRIPTION
This PR adds a new macro define option `PLOG_NO_CAPTURE_FUNCTION_NAME` which allows to disable the capture of the function name (actually the captured string also includes the parameter names & types) into the `Record` class.

This is needed when a binary is built and distributed which should not allow to reverse-engineer function names but where the logging functionality should still be used.

You can see the strings which get embedded in the built binary for the demo sample like this:
```
$ strings samples/Demo/Demo | grep "MyClass::"
void MyClass::inlineMethod()
?Date;Time;Severity;TID;This;Funcstatic void MyClass::staticMethod()
MyClass::~MyClass()
MyClass::MyClass()
void MyClass::method()
```

When building this binary with  `PLOG_NO_CAPTURE_FUNCTION_NAME` set:
```
$ strings samples/Demo/Demo | grep "MyClass::"
<no output>
```

This PR also adds unit tests for the new `PLOG_NO_CAPTURE_FUNCTION_NAME` option.

